### PR TITLE
limit stomp.py to versions <5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="scientificsoftware@diamond.ac.uk",
     download_url="https://github.com/DiamondLightSource/python-workflows/releases",
     version="1.7.1",
-    install_requires=['enum34;python_version<"3.4"', "setuptools", "six", "stomp.py"],
+    install_requires=['enum34;python_version<"3.4"', "setuptools", "six", "stomp.py<5"],
     packages=find_packages(),
     license="BSD",
     entry_points={


### PR DESCRIPTION
due to not yet supported API changes