### PR TITLE
Draft: allow injecting cmd line opts into services

### DIFF
--- a/workflows/frontend/__init__.py
+++ b/workflows/frontend/__init__.py
@@ -28,6 +28,7 @@ class Frontend:
         restart_service=False,
         verbose_service=False,
         environment=None,
+        service_args={},
     ):
         """Create a frontend instance. Connect to the transport layer, start any
         requested service, begin broadcasting status information and listen
@@ -57,6 +58,7 @@ class Frontend:
         self._service_name = None
         self._service_starttime = None
         self._service_rapidstarts = None
+        self._service_args = service_args
         self._pipe_commands = None  # frontend -> service
         self._pipe_service = None  # frontend <- service
         self._service_status = CommonService.SERVICE_STATUS_NONE
@@ -404,7 +406,10 @@ class Frontend:
             self._service = multiprocessing.Process(
                 target=service_instance.start,
                 args=(),
-                kwargs={"verbose_log": self._verbose_service},
+                kwargs={
+                    "verbose_log": self._verbose_service,
+                    "service_args": self._service_args,
+                },
             )
             self._service_name = service_instance.get_name()
             self._service_class_name = service_instance.__class__.__name__

--- a/workflows/services/common_service.py
+++ b/workflows/services/common_service.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import queue
 import threading
+import argparse
 
 import workflows
 import workflows.logging
@@ -149,6 +150,18 @@ class CommonService:
 
         # Logger will be overwritten in start() function
         self.log = logging.getLogger(self._logger_name)
+
+    @staticmethod
+    def on_parser_preparation(parser):
+        """Plugin hook to manipulate the argparse object before command line
+        parsing. If a value is returned here it will replace the OptionParser
+        object."""
+
+    @staticmethod
+    def on_parsing(args):
+        """Plugin hook to manipulate the command line parsing results.
+        A tuple of values can be returned, which will replace (args).
+        """
 
     def __send_to_frontend(self, data_structure):
         """Put a message in the pipe for the frontend."""
@@ -360,6 +373,13 @@ class CommonService:
 
         # Keep a copy of keyword arguments for use in subclasses
         self.start_kwargs.update(kwargs)
+
+        # Allow service to accept arguments
+        parser = argparse.ArgumentParser()
+        self.on_parser_preparation(parser)
+        args = parser.parse_args(self.start_kwargs.get("service_args"))
+        args = self.on_parsing(args) or args
+
         try:
             self.initialize_logging()
 

--- a/workflows/services/common_service.py
+++ b/workflows/services/common_service.py
@@ -377,7 +377,7 @@ class CommonService:
         # Allow service to accept arguments
         parser = argparse.ArgumentParser()
         self.on_parser_preparation(parser)
-        args = parser.parse_args(self.start_kwargs.get("service_args"))
+        args = parser.parse_args(self.start_kwargs.get("service_args", []))
         args = self.on_parsing(args) or args
 
         try:


### PR DESCRIPTION
Also migrate to argparse. 
Requires a similar update to `python-zocalo` to replace `parser.add_option` with `parser.add_argument`

Services can now register args in a similar way to the service runner:
```
class Service(CommonService):
    ...
    def on_parser_preparation(self, parser):
        parser.add_argument(
            "--queue", dest="queue", help="Specific queue to subscribe to"
        )

    def on_parsing(self, args):
        self.custom_queue = args.queue
```

Still to do: how to handle unknown args which now throw error in service, would be better to handle this without the exceptions
```
(zocalo) Egremont:python-workflows Stu$ zocalo.service -s Runner --test -v --moo
No env specificed for plugin graylog, will return first plugin instance
Started service: Runner
usage: zocalo.service [-h] [--queue QUEUE]
zocalo.service: error: unrecognized arguments: --moo
Service may have died unexpectedly in initialization (last known status: constructing)
Traceback (most recent call last):
  File "/Users/Stu/ESRF/zocalo/python-workflows/workflows/frontend/__init__.py", line 181, in run
    message = self._pipe_service.recv()
  File "/Users/Stu/miniconda2/envs/zocalo/lib/python3.7/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/Users/Stu/miniconda2/envs/zocalo/lib/python3.7/multiprocessing/connection.py", line 407, in _recv_bytes
    buf = self._recv(4)
  File "/Users/Stu/miniconda2/envs/zocalo/lib/python3.7/multiprocessing/connection.py", line 383, in _recv
    raise EOFError
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/Stu/miniconda2/envs/zocalo/bin/zocalo.service", line 33, in <module>
    sys.exit(load_entry_point('zocalo', 'console_scripts', 'zocalo.service')())
  File "/Users/Stu/ESRF/zocalo/python-zocalo/zocalo/service/__init__.py", line 22, in start_service
    transport_command_channel="command",
  File "/Users/Stu/ESRF/zocalo/python-workflows/workflows/contrib/start_service.py", line 146, in run
    frontend.run()
  File "/Users/Stu/ESRF/zocalo/python-workflows/workflows/frontend/__init__.py", line 228, in run
    raise workflows.Error(error_message)
workflows.Error: Service may have died unexpectedly in initialization (last known status: constructing)
```