### PR TITLE
turn Decimals into floats

### DIFF
--- a/workflows/transport/common_transport.py
+++ b/workflows/transport/common_transport.py
@@ -447,8 +447,8 @@ class CommonTransport:
 
 
 def json_serializer(obj):
-    """A helper function for JSON serialisation, where it can be used as
-    the default= argument. This function helps the serialiser to translate
+    """A helper function for JSON serialization, where it can be used as
+    the default= argument. This function helps the serializer to translate
     objects that otherwise would not be understood. Note that this is
     one-way only - these objects are not restored on the receiving end."""
 

--- a/workflows/transport/common_transport.py
+++ b/workflows/transport/common_transport.py
@@ -1,3 +1,4 @@
+import decimal
 import logging
 
 import workflows
@@ -443,3 +444,16 @@ class CommonTransport:
         """Function that any message will pass through before it being forwarded to
         the receiving subscribed callback functions."""
         return message
+
+
+def json_serializer(obj):
+    """A helper function for JSON serialisation, where it can be used as
+    the default= argument. This function helps the serialiser to translate
+    objects that otherwise would not be understood. Note that this is
+    one-way only - these objects are not restored on the receiving end."""
+
+    if isinstance(obj, decimal.Decimal):
+        # turn all Decimals into floats
+        return float(obj)
+
+    raise TypeError(repr(obj) + " is not JSON serializable")

--- a/workflows/transport/pika_transport.py
+++ b/workflows/transport/pika_transport.py
@@ -6,7 +6,7 @@ import random
 
 import pika
 import workflows
-from workflows.transport.common_transport import CommonTransport
+from workflows.transport.common_transport import CommonTransport, json_serializer
 
 
 class PikaTransport(CommonTransport):
@@ -577,7 +577,7 @@ class PikaTransport(CommonTransport):
         the actual _send* functions.
         Pika only deals with serialized strings, so serialize message as json.
         """
-        return json.dumps(message)
+        return json.dumps(message, default=json_serializer)
 
     @staticmethod
     def _mangle_for_receiving(message):

--- a/workflows/transport/stomp_transport.py
+++ b/workflows/transport/stomp_transport.py
@@ -5,7 +5,7 @@ import time
 
 import stomp
 import workflows
-from workflows.transport.common_transport import CommonTransport
+from workflows.transport.common_transport import CommonTransport, json_serializer
 
 
 class StompTransport(CommonTransport):
@@ -468,7 +468,7 @@ class StompTransport(CommonTransport):
         the actual _send* functions.
         Stomp only deals with serialized strings, so serialize message as json.
         """
-        return json.dumps(message)
+        return json.dumps(message, default=json_serializer)
 
     @staticmethod
     def _mangle_for_receiving(message):

--- a/workflows/transport/test_stomp_transport.py
+++ b/workflows/transport/test_stomp_transport.py
@@ -348,8 +348,8 @@ def test_error_handling_on_broadcast(mockstomp):
 @mock.patch("workflows.transport.stomp_transport.stomp")
 def test_messages_are_serialized_for_transport(mockstomp):
     """Test the message serialization."""
-    banana = {"entry": [decimal.Decimal(0), "banana"]}
-    banana_str = '{"entry": [0, "banana"]}'
+    banana = {"entry": [1, 2.0, decimal.Decimal(3), "banana"]}
+    banana_str = '{"entry": [1, 2.0, 3.0, "banana"]}'
     stomp = StompTransport()
     stomp.connect()
     mockconn = mockstomp.Connection.return_value

--- a/workflows/transport/test_stomp_transport.py
+++ b/workflows/transport/test_stomp_transport.py
@@ -1,4 +1,5 @@
 import argparse
+import decimal
 import importlib
 import inspect
 import json
@@ -347,7 +348,7 @@ def test_error_handling_on_broadcast(mockstomp):
 @mock.patch("workflows.transport.stomp_transport.stomp")
 def test_messages_are_serialized_for_transport(mockstomp):
     """Test the message serialization."""
-    banana = {"entry": [0, "banana"]}
+    banana = {"entry": [decimal.Decimal(0), "banana"]}
     banana_str = '{"entry": [0, "banana"]}'
     stomp = StompTransport()
     stomp.connect()


### PR DESCRIPTION
when sending messages.

This is somewhat preferable over crashing, even if it means losing precision.