### PR TITLE
Add a Zocalo plugin to enable stomp configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ workflows.services =
 workflows.transport =
     StompTransport = workflows.transport.stomp_transport:StompTransport
     PikaTransport = workflows.transport.pika_transport:PikaTransport
+zocalo.configuration.plugins =
+    stomp = workflows.contrib.zocalo_configuration:StompPlugin
 
 [options.packages.find]
 where = src

--- a/src/workflows/contrib/zocalo_configuration.py
+++ b/src/workflows/contrib/zocalo_configuration.py
@@ -1,0 +1,26 @@
+from marshmallow import fields
+from zocalo.configuration import PluginSchema
+
+from workflows.transport.stomp_transport import StompTransport
+
+
+class StompPlugin:
+    """A Zocalo configuration plugin to pre-populate StompTransport config defaults"""
+
+    class Schema(PluginSchema):
+        host = fields.Str(required=True)
+        port = fields.Int(required=True)
+        username = fields.Str(required=True)
+        password = fields.Str(required=True)
+        prefix = fields.Str(required=True)
+
+    @staticmethod
+    def activate(configuration):
+        for cfgoption, target in [
+            ("host", "--stomp-host"),
+            ("port", "--stomp-port"),
+            ("password", "--stomp-pass"),
+            ("username", "--stomp-user"),
+            ("prefix", "--stomp-prfx"),
+        ]:
+            StompTransport.defaults[target] = configuration[cfgoption]


### PR DESCRIPTION
This is using the new Zocalo configuration API (cf. DiamondLightSource/python-zocalo#90), and will only have any effect if a compatible version of Zocalo is installed.