### PR TITLE
Add a reconnection mechanism to recipe wrappers

### DIFF
--- a/src/workflows/recipe/wrapper.py
+++ b/src/workflows/recipe/wrapper.py
@@ -252,7 +252,6 @@ class RecipeWrapper:
                 delay = attempt * attempt * 3
                 # wait 3, 12, 27, 48, 75, 108, 147, 192, 243, 300 seconds
                 # between attempts
-                delay = 1
                 logger.warning(
                     "Connection failure detected during send attempt."
                     " Retrying in %d seconds",

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -316,6 +316,12 @@ class CommonTransport:
         self.__transactions.remove(transaction_id)
         self._transaction_commit(transaction_id, **kwargs)
 
+    @property
+    def is_reconnectable(self):
+        """Check if the transport object is in a status where reconnecting is
+        supported. There must not be any active subscriptions or transactions."""
+        return not self.__subscriptions and not self.__transactions
+
     #
     # -- Low level communication calls to be implemented by subclass -----------
     #


### PR DESCRIPTION
the reconnection mechanism only works on connections that have neither
active subscriptions nor active transactions, as the semantics of those
would be broken by automatic reconnection.