### PR TITLE
Running tests requires the pytest-timeout plugin

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = -ra
+required_plugins = pytest-timeout


### PR DESCRIPTION
so ensure it is present before running tests