### PR TITLE
Remove stomp transport transformation parameter

### DIFF
--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -295,8 +295,6 @@ class StompTransport(CommonTransport):
           selector:         Only receive messages filtered by a selector. See
                             https://activemq.apache.org/activemq-message-properties.html
                             for potential filter criteria. Uses SQL 92 syntax.
-          transformation:   Transform messages into different format. If set
-                            to True, will use 'jms-object-json' formatting.
         """
         headers = {}
         if kwargs.get("exclusive"):
@@ -311,11 +309,6 @@ class StompTransport(CommonTransport):
             headers["activemq.retroactive"] = "true"
         if kwargs.get("selector"):
             headers["selector"] = kwargs["selector"]
-        if kwargs.get("transformation"):
-            if kwargs["transformation"] is True:
-                headers["transformation"] = "jms-object-json"
-            else:
-                headers["transformation"] = kwargs["transformation"]
         if kwargs.get("acknowledgement"):
             ack = "client-individual"
         else:
@@ -331,8 +324,6 @@ class StompTransport(CommonTransport):
         :param **kwargs: Further parameters for the transport layer. For example
           ignore_namespace: Do not apply namespace to the destination name
           retroactive:      Ask broker to send old messages if possible
-          transformation:   Transform messages into different format. If set
-                            to True, will use 'jms-object-json' formatting.
         """
         headers = {}
         if kwargs.get("ignore_namespace"):
@@ -341,11 +332,6 @@ class StompTransport(CommonTransport):
             destination = "/topic/" + self._namespace + channel
         if kwargs.get("retroactive"):
             headers["activemq.retroactive"] = "true"
-        if kwargs.get("transformation"):
-            if kwargs["transformation"] is True:
-                headers["transformation"] = "jms-object-json"
-            else:
-                headers["transformation"] = kwargs["transformation"]
         self._conn.subscribe(destination, sub_id, headers=headers)
 
     def _unsubscribe(self, subscription, **kwargs):

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -479,14 +479,13 @@ def test_subscribe_to_queue(mockstomp):
         1,
         str(mock.sentinel.channel1),
         mock_cb1,
-        transformation=mock.sentinel.transformation,
     )
 
     mockconn.subscribe.assert_called_once()
     args, kwargs = mockconn.subscribe.call_args
     assert args == ("/queue/" + str(mock.sentinel.channel1), 1)
     assert kwargs == {
-        "headers": {"transformation": mock.sentinel.transformation},
+        "headers": {},
         "ack": "auto",
     }
 
@@ -497,7 +496,6 @@ def test_subscribe_to_queue(mockstomp):
         retroactive=True,
         selector=mock.sentinel.selector,
         exclusive=True,
-        transformation=True,
         priority=42,
     )
     assert mockconn.subscribe.call_count == 2
@@ -508,7 +506,6 @@ def test_subscribe_to_queue(mockstomp):
             "activemq.retroactive": "true",
             "selector": mock.sentinel.selector,
             "activemq.exclusive": "true",
-            "transformation": "jms-object-json",
             "activemq.priority": 42,
         },
         "ack": "auto",
@@ -560,23 +557,20 @@ def test_subscribe_to_broadcast(mockstomp):
         1,
         str(mock.sentinel.channel1),
         mock_cb1,
-        transformation=mock.sentinel.transformation,
     )
 
     mockconn.subscribe.assert_called_once()
     args, kwargs = mockconn.subscribe.call_args
     assert args == ("/topic/" + str(mock.sentinel.channel1), 1)
-    assert kwargs == {"headers": {"transformation": mock.sentinel.transformation}}
+    assert kwargs == {"headers": {}}
 
     stomp._subscribe_broadcast(
-        2, str(mock.sentinel.channel2), mock_cb2, retroactive=True, transformation=True
+        2, str(mock.sentinel.channel2), mock_cb2, retroactive=True
     )
     assert mockconn.subscribe.call_count == 2
     args, kwargs = mockconn.subscribe.call_args
     assert args == ("/topic/" + str(mock.sentinel.channel2), 2)
-    assert kwargs == {
-        "headers": {"activemq.retroactive": "true", "transformation": "jms-object-json"}
-    }
+    assert kwargs == {"headers": {"activemq.retroactive": "true"}}
 
     assert mock_cb1.call_count == 0
     listener.on_message(_frame({"subscription": 1}, mock.sentinel.message1))


### PR DESCRIPTION
I believe this is not used anywhere and can be removed safely.