### PR TITLE
Add --transport in transport.add_command_line_options

### DIFF
--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -74,17 +74,7 @@ class ServiceStarter:
             help="Name of the service to start. Known services: "
             + ", ".join(known_services),
         )
-        parser.add_option(
-            "-t",
-            "--transport",
-            dest="transport",
-            metavar="TRN",
-            default=workflows.transport.default_transport,
-            help="Transport mechanism. Known mechanisms: "
-            + ", ".join(workflows.transport.get_known_transports())
-            + " (default: %default)",
-        )
-        workflows.transport.add_command_line_options(parser)
+        workflows.transport.add_command_line_options(parser, transport_argument=True)
 
         # Call on_parser_preparation hook
         parser = self.on_parser_preparation(parser) or parser

--- a/src/workflows/transport/__init__.py
+++ b/src/workflows/transport/__init__.py
@@ -1,3 +1,7 @@
+import argparse
+import optparse
+from typing import Union
+
 import pkg_resources
 
 default_transport = "StompTransport"
@@ -10,8 +14,34 @@ def lookup(transport):
     )
 
 
-def add_command_line_options(parser):
+def add_command_line_options(
+    parser: Union[argparse.ArgumentParser, optparse.OptionParser],
+    transport_argument: bool = False,
+) -> None:
     """Add command line options for all available transport layer classes."""
+    if transport_argument:
+        if isinstance(parser, argparse.ArgumentParser):
+            parser.add_argument(
+                "-t",
+                "--transport",
+                dest="transport",
+                metavar="TRN",
+                default=default_transport,
+                help="Transport mechanism. Known mechanisms: "
+                + ", ".join(get_known_transports())
+                + f" (default: {default_transport})",
+            )
+        else:
+            parser.add_option(
+                "-t",
+                "--transport",
+                dest="transport",
+                metavar="TRN",
+                default=default_transport,
+                help="Transport mechanism. Known mechanisms: "
+                + ", ".join(get_known_transports())
+                + " (default: %default)",
+            )
     for transport in get_known_transports().values():
         transport().add_command_line_options(parser)
 


### PR DESCRIPTION
This reduces copy-pasta in every cli that supports setting transport type.
Make transport_argument optional for backwards compatibility