### PR TITLE
Add Zocalo config plugin to set default transport

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ workflows.transport =
 zocalo.configuration.plugins =
     pika = workflows.util.zocalo.configuration:Pika
     stomp = workflows.util.zocalo.configuration:Stomp
+    transport = workflows.util.zocalo.configuration:DefaultTransport
 
 [options.packages.find]
 where = src

--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -1,6 +1,7 @@
 from marshmallow import fields
 from zocalo.configuration import PluginSchema
 
+import workflows.transport
 from workflows.transport.pika_transport import PikaTransport
 from workflows.transport.stomp_transport import StompTransport
 
@@ -47,3 +48,14 @@ class Pika:
             ("vhost", "--rabbit-vhost"),
         ]:
             PikaTransport.defaults[target] = configuration[cfgoption]
+
+
+class DefaultTransport:
+    """A Zocalo configuration plugin to set a default transport class"""
+
+    class Schema(PluginSchema):
+        default = fields.Str(required=True)
+
+    @staticmethod
+    def activate(configuration):
+        workflows.transport.default_transport = configuration["default"]


### PR DESCRIPTION
To allow specifying a default transport in a site configuration file, for example with:

```yaml
offline-default-transport:
  plugin: transport
  default: OfflineTransport
```

addresses https://github.com/DiamondLightSource/python-zocalo/pull/134#issuecomment-933789109