### PR TITLE
Remove timestamp references from recipe tests

### DIFF
--- a/tests/recipe/test_wrap_subscription.py
+++ b/tests/recipe/test_wrap_subscription.py
@@ -44,7 +44,6 @@ def check_message_handling_via_unwrapper(
         "environment": {
             "ID": mock.sentinel.GUID,
             "source": mock.sentinel.source,
-            "timestamp": mock.sentinel.timestamp,
         },
         "payload": mock.sentinel.payload,
     }
@@ -188,7 +187,6 @@ def test_wrapping_a_subscription_with_log_extension():
         "environment": {
             "ID": mock.sentinel.GUID,
             "source": mock.sentinel.source,
-            "timestamp": mock.sentinel.timestamp,
         },
         "payload": mock.sentinel.payload,
     }

--- a/tests/recipe/test_wrapped_recipe.py
+++ b/tests/recipe/test_wrapped_recipe.py
@@ -29,7 +29,6 @@ def generate_recipe_message():
         "environment": {
             "ID": mock.sentinel.GUID,
             "source": mock.sentinel.source,
-            "timestamp": mock.sentinel.timestamp,
         },
         "payload": mock.sentinel.payload,
     }


### PR DESCRIPTION
These aren't actually there by default, so don't imply that they are