### PR TITLE
Fix an otherwise harmless race condition in test

### DIFF
--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import queue
 import threading
+import time
 from typing import Any, Dict
 
 import workflows
@@ -267,6 +268,7 @@ class CommonService:
                         exc_info=True,
                     )
                     break
+                time.sleep(0.05)
         self.log.debug("Queue listener thread terminating")
 
     def __start_command_queue_listener(self):


### PR DESCRIPTION
specifically test_common_service.py::test_log_unknown_band_data.

Shutdown of the queue listener thread doesn't happen immediately as it
also depends on the main thread acting first. Therefore the queue
listener thread may encounter the injected Exception even though all the
events are happening in the right order.