### PR TITLE
Allow subscribing to temporary queues

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -348,7 +348,7 @@ class PikaTransport(CommonTransport):
         exclusive: bool = False,
         prefetch_count: int = 1,
         reconnectable: bool = False,
-        temporary: bool = False,
+        auto_delete: bool = False,
         **_kwargs,
     ):
         """
@@ -372,6 +372,7 @@ class PikaTransport(CommonTransport):
                 How many messages will be prefetched for the subscription.
                 This makes little difference unless acknowledgement is
                 also set.
+            auto_delete: Delete after consumer cancels or disconnects
         """
         if acknowledgement and reconnectable:
             raise ValueError(
@@ -390,7 +391,7 @@ class PikaTransport(CommonTransport):
                 queue=channel,
                 callback=functools.partial(self._call_message_callback, sub_id),
                 auto_ack=not acknowledgement,
-                auto_delete=temporary,
+                auto_delete=auto_delete,
                 exclusive=exclusive,
                 subscription_id=sub_id,
                 reconnectable=reconnectable,

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -595,6 +595,7 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 1,
         "exclusive": False,
@@ -610,6 +611,7 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 2,
         "exclusive": False,
@@ -624,11 +626,26 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": False,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 3,
         "exclusive": False,
         "prefetch_count": 1,
         "queue": str(mock.sentinel.queue3),
+        "reconnectable": False,
+    }
+
+    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, temporary=True)
+    assert mock_pikathread.subscribe_queue.call_count == 4
+    args, kwargs = mock_pikathread.subscribe_queue.call_args
+    assert kwargs == {
+        "auto_ack": True,
+        "auto_delete": True,
+        "callback": mock.ANY,
+        "subscription_id": 4,
+        "exclusive": False,
+        "prefetch_count": 1,
+        "queue": str(mock.sentinel.queue4),
         "reconnectable": False,
     }
 

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -635,7 +635,7 @@ def test_subscribe_to_queue(mock_pikathread):
         "reconnectable": False,
     }
 
-    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, temporary=True)
+    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, auto_delete=True)
     assert mock_pikathread.subscribe_queue.call_count == 4
     args, kwargs = mock_pikathread.subscribe_queue.call_args
     assert kwargs == {


### PR DESCRIPTION
For use in Zocalo system tests