### PR TITLE
Enable explicit queue declaration via transport layer

### DIFF
--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -336,9 +336,13 @@ class CommonTransport:
         supported. There must not be any active subscriptions or transactions."""
         return not self.__subscriptions and not self.__transactions
 
-    def queue_declare(self, queue: str = "", **kwargs) -> str:
+    def queue_declare(self, queue: str = "", temporary: bool = True, **kwargs) -> str:
         """Declare a queue with optional name, returning the name of the queue."""
-        return self._queue_declare(queue, **kwargs)
+        if not temporary:
+            raise NotImplementedError(
+                "Only declaration of temporary queues is currently supported."
+            )
+        return self._queue_declare(queue=queue, temporary=temporary, **kwargs)
 
     #
     # -- Low level communication calls to be implemented by subclass -----------
@@ -441,7 +445,7 @@ class CommonTransport:
         """
         raise NotImplementedError("Transport interface not implemented")
 
-    def _queue_declare(self, queue: str = "", **kwargs) -> str:
+    def _queue_declare(self, queue: str = "", temporary: bool = True, **kwargs) -> str:
         """Declare a queue with optional name, returning the name of the queue."""
         raise NotImplementedError("Queue declaration interface not implemented")
 

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -336,6 +336,10 @@ class CommonTransport:
         supported. There must not be any active subscriptions or transactions."""
         return not self.__subscriptions and not self.__transactions
 
+    def queue_declare(self, queue: str = "", **kwargs) -> str:
+        """Declare a queue with optional name, returning the name of the queue."""
+        return self._queue_declare(queue, **kwargs)
+
     #
     # -- Low level communication calls to be implemented by subclass -----------
     #
@@ -436,6 +440,10 @@ class CommonTransport:
         :param **kwargs: Further parameters for the transport layer.
         """
         raise NotImplementedError("Transport interface not implemented")
+
+    def _queue_declare(self, queue: str = "", **kwargs) -> str:
+        """Declare a queue with optional name, returning the name of the queue."""
+        raise NotImplementedError("Queue declaration interface not implemented")
 
     #
     # -- Internal message mangling functions -----------------------------------

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1386,9 +1386,7 @@ class _PikaThread(threading.Thread):
         arguments: Optional[dict] = None,
     ):
         """Declare a queue."""
-        assert self._connection is not None
-        channel = self._connection.channel()
-        qresult = channel.queue_declare(
+        qresult = self._get_shared_channel().queue_declare(
             queue=queue,
             passive=passive,
             durable=durable,

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -347,7 +347,7 @@ class PikaTransport(CommonTransport):
         acknowledgement: bool = False,
         prefetch_count: int = 1,
         reconnectable: bool = False,
-        temporary: bool = False,
+        auto_delete: bool = False,
         **_kwargs,
     ):
         """
@@ -370,6 +370,7 @@ class PikaTransport(CommonTransport):
                 How many messages will be prefetched for the subscription.
                 This makes little difference unless acknowledgement is
                 also set.
+            auto_delete: Delete after consumer cancels or disconnects
         """
         if acknowledgement and reconnectable:
             raise ValueError(
@@ -388,7 +389,7 @@ class PikaTransport(CommonTransport):
                 queue=channel,
                 callback=functools.partial(self._call_message_callback, sub_id),
                 auto_ack=not acknowledgement,
-                auto_delete=temporary,
+                auto_delete=auto_delete,
                 subscription_id=sub_id,
                 reconnectable=reconnectable,
                 prefetch_count=prefetch_count,

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -583,11 +583,11 @@ class PikaTransport(CommonTransport):
     def _queue_declare(
         self,
         queue: str = "",
+        temporary: bool = True,
         *,
         passive: bool = False,
         durable: bool = False,
         exclusive: bool = False,
-        auto_delete: bool = False,
         arguments: Optional[dict] = None,
         **_kwargs,
     ) -> str:
@@ -597,7 +597,7 @@ class PikaTransport(CommonTransport):
             passive=passive,
             durable=durable,
             exclusive=exclusive,
-            auto_delete=auto_delete,
+            auto_delete=temporary,
             arguments=arguments,
         ).result()
 
@@ -1105,7 +1105,7 @@ class _PikaThread(threading.Thread):
         passive: bool = False,
         durable: bool = False,
         exclusive: bool = False,
-        auto_delete: bool = False,
+        auto_delete: bool = True,
         arguments: Optional[dict] = None,
         **_kwargs,
     ) -> Future[str]:
@@ -1113,7 +1113,6 @@ class _PikaThread(threading.Thread):
 
         Warning: this should only be used for declaring temporary queues.
         """
-
         if not self._connection:
             raise RuntimeError("Cannot subscribe to unstarted connection")
 

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1215,7 +1215,7 @@ class _PikaThread(threading.Thread):
         if subscription.kind is _PikaSubscriptionKind.FANOUT:
             # If a FANOUT subscription, then we need to create and bind
             # a temporary queue to receive messages from the exchange
-            queue = self._queue_declare("", exclusive=True)
+            queue = channel.queue_declare("", exclusive=True).method.queue
             assert queue is not None
             channel.queue_bind(queue, subscription.destination)
             subscription.queue = queue

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1114,6 +1114,10 @@ class _PikaThread(threading.Thread):
         arguments: Optional[dict] = None,
         **_kwargs,
     ) -> Future[str]:
+        """Declare a queue. Thread-safe.
+
+        Warning: this should only be used for declaring temporary queues.
+        """
 
         if not self._connection:
             raise RuntimeError("Cannot subscribe to unstarted connection")

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -347,7 +347,6 @@ class PikaTransport(CommonTransport):
         acknowledgement: bool = False,
         prefetch_count: int = 1,
         reconnectable: bool = False,
-        auto_delete: bool = False,
         **_kwargs,
     ):
         """
@@ -389,7 +388,6 @@ class PikaTransport(CommonTransport):
                 queue=channel,
                 callback=functools.partial(self._call_message_callback, sub_id),
                 auto_ack=not acknowledgement,
-                auto_delete=auto_delete,
                 subscription_id=sub_id,
                 reconnectable=reconnectable,
                 prefetch_count=prefetch_count,
@@ -682,7 +680,6 @@ class _PikaSubscription:
     prefetch_count: int
     queue: Optional[str] = dataclasses.field(init=False, default=None)
     reconnectable: bool
-    auto_delete: bool = False
 
 
 class _PikaThread(threading.Thread):
@@ -827,7 +824,6 @@ class _PikaThread(threading.Thread):
         auto_ack: bool = True,
         prefetch_count: int = 1,
         reconnectable: bool = False,
-        auto_delete: bool = False,
     ) -> Future[None]:
         """
         Subscribe to a queue. Thread-safe.
@@ -851,7 +847,6 @@ class _PikaThread(threading.Thread):
         new_sub = _PikaSubscription(
             arguments={},
             auto_ack=auto_ack,
-            auto_delete=auto_delete,
             destination=queue,
             kind=_PikaSubscriptionKind.DIRECT,
             on_message_callback=callback,
@@ -1226,8 +1221,6 @@ class _PikaThread(threading.Thread):
             subscription.queue = queue
         elif subscription.kind is _PikaSubscriptionKind.DIRECT:
             subscription.queue = subscription.destination
-            if subscription.auto_delete:
-                self._queue_declare(subscription.queue, auto_delete=True)
         else:
             raise NotImplementedError(f"Unknown subscription kind: {subscription.kind}")
         channel.basic_consume(

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1376,26 +1376,6 @@ class _PikaThread(threading.Thread):
             result.set_exception(e)
             raise
 
-    def _queue_declare(
-        self,
-        queue: str = "",
-        passive: bool = False,
-        durable: bool = False,
-        exclusive: bool = False,
-        auto_delete: bool = False,
-        arguments: Optional[dict] = None,
-    ):
-        """Declare a queue."""
-        qresult = self._get_shared_channel().queue_declare(
-            queue=queue,
-            passive=passive,
-            durable=durable,
-            exclusive=exclusive,
-            auto_delete=auto_delete,
-            arguments=arguments,
-        )
-        return qresult.method.queue
-
     def _declare_queue_in_thread(
         self,
         result: Future,
@@ -1413,13 +1393,17 @@ class _PikaThread(threading.Thread):
         """
         try:
             if result.set_running_or_notify_cancel():
-                queue = self._queue_declare(
-                    queue=queue,
-                    passive=passive,
-                    durable=durable,
-                    exclusive=exclusive,
-                    auto_delete=auto_delete,
-                    arguments=arguments,
+                queue = (
+                    self._get_shared_channel()
+                    .queue_declare(
+                        queue=queue,
+                        passive=passive,
+                        durable=durable,
+                        exclusive=exclusive,
+                        auto_delete=auto_delete,
+                        arguments=arguments,
+                    )
+                    .method.queue
                 )
                 result.set_result(queue)
         except BaseException as e:

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -447,6 +447,12 @@ class StompTransport(CommonTransport):
         """
         self._conn.nack(message_id, subscription_id, **kwargs)
 
+    def _queue_declare(self, queue: str = "", **kwargs) -> str:
+        """Declare a queue with optional name, returning the name of the queue."""
+        if not queue:
+            raise workflows.Error("StompTransport does not support empty queue name")
+        return queue
+
     @staticmethod
     def _mangle_for_sending(message):
         """Function that any message will pass through before it being forwarded to

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -699,21 +699,12 @@ def test_queue_declare(mock_pikathread):
         passive=False,
         durable=False,
         exclusive=False,
-        auto_delete=False,
+        auto_delete=True,
         arguments=None,
     )
 
-    # kwargs should be passed through to pikathread.queue_declare
-    kwargs = {
-        "queue": "foo",
-        "passive": True,
-        "durable": True,
-        "exclusive": True,
-        "auto_delete": True,
-        "arguments": {"foo": "bar"},
-    }
-    transport.queue_declare(**kwargs)
-    mock_pikathread.queue_declare.assert_called_with(**kwargs)
+    with pytest.raises(NotImplementedError):
+        transport.queue_declare(temporary=False)
 
 
 @mock.patch("workflows.transport.pika_transport.pika")

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -640,7 +640,6 @@ def test_subscribe_to_queue(mock_pikathread):
         "auto_delete": True,
         "callback": mock.ANY,
         "subscription_id": 4,
-        "exclusive": False,
         "prefetch_count": 1,
         "queue": str(mock.sentinel.queue4),
         "reconnectable": False,

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -632,7 +632,7 @@ def test_subscribe_to_queue(mock_pikathread):
         "reconnectable": False,
     }
 
-    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, temporary=True)
+    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, auto_delete=True)
     assert mock_pikathread.subscribe_queue.call_count == 4
     args, kwargs = mock_pikathread.subscribe_queue.call_args
     assert kwargs == {

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -595,7 +595,6 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
-        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 1,
         "prefetch_count": 1,
@@ -610,7 +609,6 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
-        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 2,
         "prefetch_count": 1,
@@ -624,7 +622,6 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": False,
-        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 3,
         "prefetch_count": 1,
@@ -637,7 +634,6 @@ def test_subscribe_to_queue(mock_pikathread):
     args, kwargs = mock_pikathread.subscribe_queue.call_args
     assert kwargs == {
         "auto_ack": True,
-        "auto_delete": True,
         "callback": mock.ANY,
         "subscription_id": 4,
         "prefetch_count": 1,

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -595,6 +595,7 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 1,
         "prefetch_count": 1,
@@ -609,6 +610,7 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": True,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 2,
         "prefetch_count": 1,
@@ -622,10 +624,25 @@ def test_subscribe_to_queue(mock_pikathread):
     assert not args
     assert kwargs == {
         "auto_ack": False,
+        "auto_delete": False,
         "callback": mock.ANY,
         "subscription_id": 3,
         "prefetch_count": 1,
         "queue": str(mock.sentinel.queue3),
+        "reconnectable": False,
+    }
+
+    transport._subscribe(4, str(mock.sentinel.queue4), mock_cb, temporary=True)
+    assert mock_pikathread.subscribe_queue.call_count == 4
+    args, kwargs = mock_pikathread.subscribe_queue.call_args
+    assert kwargs == {
+        "auto_ack": True,
+        "auto_delete": True,
+        "callback": mock.ANY,
+        "subscription_id": 4,
+        "exclusive": False,
+        "prefetch_count": 1,
+        "queue": str(mock.sentinel.queue4),
         "reconnectable": False,
     }
 

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -704,3 +704,26 @@ def test_namespace_is_used_correctly(mockstomp):
 
     stomp.broadcast_status("some status")
     assert mockconn.send.call_args[0] == ("/topic/ns.transient.status", '"some status"')
+
+
+@mock.patch("workflows.transport.stomp_transport.stomp")
+def test_queue_declare(mockstomp):
+    """Test the broadcast sending function."""
+    stomp = StompTransport()
+    stomp.connect()
+
+    # Declare 10 queues and assert they all have unique queue names
+    # of the form "transient.*"
+    queues = {stomp._queue_declare() for i in range(10)}
+    assert len(queues) == 10
+    assert all(q.startswith("transient.") for q in queues)
+
+    # Declare 10 queues and assert they all have unique queue names
+    # of the form "transient.foo.*"
+    queues = {stomp._queue_declare("foo") for i in range(10)}
+    assert len(queues) == 10
+    assert all(q.startswith("transient.foo.") for q in queues)
+
+    # Explicit queue name should be returned as-is
+    queue = "transient.foo.12345"
+    assert stomp._queue_declare(queue) == queue


### PR DESCRIPTION
Alternative to https://github.com/DiamondLightSource/python-workflows/pull/87 requiring explicit declaration of temporary queues ahead of subscription.