### PR TITLE
Enforce transaction semantics on RabbitMQ

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+bidict==0.21.4
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-timeout==2.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ project-urls =
 
 [options]
 install_requires =
+    bidict
     pika
     setuptools
     stomp.py>=7

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -764,7 +764,10 @@ def test_ack_message(mock_pikathread):
 
     transport._ack(mock.sentinel.messageid, mock.sentinel.sub_id)
     mock_pikathread.ack.assert_called_once_with(
-        mock.sentinel.messageid, mock.sentinel.sub_id, multiple=False
+        mock.sentinel.messageid,
+        mock.sentinel.sub_id,
+        multiple=False,
+        transaction_id=None,
     )
 
 
@@ -776,7 +779,11 @@ def test_nack_message(mock_pikathread):
     transport._nack(mock.sentinel.messageid, mock.sentinel.sub_id)
 
     mock_pikathread.nack.assert_called_once_with(
-        mock.sentinel.messageid, mock.sentinel.sub_id, multiple=False, requeue=True
+        mock.sentinel.messageid,
+        mock.sentinel.sub_id,
+        multiple=False,
+        requeue=True,
+        transaction_id=None,
     )
 
 

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -787,7 +787,7 @@ def test_nack_message(mock_pikathread):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def connection_params():
     """Connection Parameters for connecting to a physical RabbitMQ server"""
     params = [


### PR DESCRIPTION
If a transaction is running on an outgoing channel then all messages
going out on that channel must either match this transaction, or - if
they are outside of a transaction - must be committed immediately.
If a transaction is running, has uncommitted messages, and then a
message is sent outside of a transaction an error must be raised, as
RabbitMQ does not support this behaviour.

The only messages outgoing on a transacting, subscribing channel are
ACK/NACK and transacted sends. (Untransacted sends do not go through
this channel, so do not need to be considered.) In all three cases,
set a flag if there are uncommitted messages on the transaction to
detect the above case, so that an error can be raised.

This adds a package dependency on [bidict](https://pypi.org/project/bidict/) and closes #97 