### PR TITLE
Make _PikaThread explicitly daemonic

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -696,9 +696,7 @@ class _PikaThread(threading.Thread):
         connection_parameters: Iterable[pika.ConnectionParameters],
         reconnection_attempts=5,
     ):
-        super().__init__(
-            name="workflows pika_transport", daemon=False, target=self._run
-        )
+        super().__init__(name="workflows pika_transport", daemon=True, target=self._run)
         self._state: _PikaThreadStatus = _PikaThreadStatus.NEW
         # Internal store of subscriptions, to resubscribe if necessary. Keys are
         # unique and auto-generated, and known as subscription IDs or consumer tags


### PR DESCRIPTION
Issue raised by https://github.com/DiamondLightSource/python-zocalo/pull/146 - this should not hold the process open if not shut down correctly.