### PR TITLE
Add common transport API for subscriptions to a temporary queue

### DIFF
--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -105,8 +105,10 @@ class CommonTransport:
         """
         self.__subscription_id += 1
 
-        def mangled_callback(header: Mapping[str, Any], message: Any, /) -> None:
+        def _(header: Mapping[str, Any], message: Any) -> None:
             callback(header, self._mangle_for_receiving(message))
+
+        mangled_callback: MessageCallback = _
 
         if "disable_mangling" in kwargs:
             if kwargs["disable_mangling"]:

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -123,10 +123,12 @@ class CommonTransport:
             channel_hint,
             self.__subscription_id,
         )
-        # self._subscribe(self.__subscription_id, channel, mangled_callback, **kwargs)
+        queue_name = self._subscribe_temporary(
+            self.__subscription_id, channel_hint, mangled_callback, **kwargs
+        )
 
         return TemporarySubscription(
-            subscription_id=self.__subscription_id, queue_name=""
+            subscription_id=self.__subscription_id, queue_name=queue_name
         )
 
     def unsubscribe(self, subscription: int, drop_callback_reference=False, **kwargs):
@@ -410,6 +412,24 @@ class CommonTransport:
         :param callback: Function to be called when messages are received
         :param **kwargs: Further parameters for the transport layer. For example
                retroactive: Ask broker to send old messages if possible
+        """
+        raise NotImplementedError("Transport interface not implemented")
+
+    def _subscribe_temporary(
+        self,
+        sub_id: int,
+        channel_hint: Optional[str],
+        callback: MessageCallback,
+        **kwargs,
+    ) -> str:
+        """Create and then listen to a temporary queue, notify via callback function.
+        :param sub_id: ID for this subscription in the transport layer
+        :param channel_hint: Name suggestion for the temporary queue
+        :param callback: Function to be called when messages are received
+        :param **kwargs: Further parameters for the transport layer. For example
+               acknowledgement: If true receipt of each message needs to be
+                                acknowledged.
+        :returns: The name of the temporary queue
         """
         raise NotImplementedError("Transport interface not implemented")
 

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import decimal
 import logging
-from typing import Any, Callable, Dict, Mapping, Optional, Set
+from typing import Any, Callable, Dict, Mapping, NamedTuple, Optional, Set
 
 import workflows
 
 MessageCallback = Callable[[Mapping[str, Any], Any], None]
-
-from typing import NamedTuple
 
 
 class TemporarySubscription(NamedTuple):

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -452,9 +452,10 @@ class PikaTransport(CommonTransport):
             The name of the temporary queue
         """
         queue: str = channel_hint or ""
-        if queue and not queue.startswith("transient."):
-            queue = "transient." + queue
-        queue = queue + "." + str(uuid.uuid4())
+        if queue:
+            if not queue.startswith("transient."):
+                queue = "transient." + queue
+            queue = queue + "." + str(uuid.uuid4())
 
         try:
             return self._pika_thread.subscribe_temporary(

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -9,15 +9,15 @@ import random
 import sys
 import threading
 import time
+import uuid
 from concurrent.futures import Future
 from enum import Enum, auto
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
-import pika
 import pika.exceptions
 from pika.adapters.blocking_connection import BlockingChannel
 
-import workflows
+import workflows.util
 from workflows.transport.common_transport import (
     CommonTransport,
     MessageCallback,
@@ -414,8 +414,7 @@ class PikaTransport(CommonTransport):
         Args:
             sub_id: Internal ID for this subscription
             channel: Name of the exchange to bind to
-            callback:
-                Function to be called when message are received
+            callback: Function to be called when messages are received
             reconnectable:
                 Can we reconnect to this exchange if the connection is
                 lost. Currently, this means that messages can be missed
@@ -428,6 +427,47 @@ class PikaTransport(CommonTransport):
             subscription_id=sub_id,
             reconnectable=reconnectable,
         ).result()
+
+    def _subscribe_temporary(
+        self,
+        sub_id: int,
+        channel_hint: Optional[str],
+        callback: MessageCallback,
+        *,
+        acknowledgement: bool = False,
+        **kwargs,
+    ) -> str:
+        """
+        Create and then listen to a temporary queue, notify via callback function.
+
+        Wait until subscription is complete.
+
+        Args:
+            sub_id: Internal ID for this subscription
+            channel_hint: Name suggestion for the temporary queue
+            callback: Function to be called when messages are received
+            acknowledgement:
+                Each message will need to be explicitly acknowledged.
+        Returns:
+            The name of the temporary queue
+        """
+        queue: str = channel_hint or ""
+        if queue and not queue.startswith("transient."):
+            queue = "transient." + queue
+        queue = queue + "." + str(uuid.uuid4())
+
+        try:
+            return self._pika_thread.subscribe_temporary(
+                queue=queue,
+                callback=functools.partial(self._call_message_callback, sub_id),
+                auto_ack=not acknowledgement,
+                subscription_id=sub_id,
+            ).result()
+        except (
+            pika.exceptions.AMQPChannelError,
+            pika.exceptions.AMQPConnectionError,
+        ) as e:
+            raise workflows.Disconnected(e)
 
     def _unsubscribe(self, sub_id: int, **kwargs):
         """Stop listening to a queue
@@ -895,6 +935,65 @@ class _PikaThread(threading.Thread):
                 self._add_subscription_in_thread, subscription_id, new_sub, result
             )
         )
+        return result
+
+    def subscribe_temporary(
+        self,
+        queue: str,
+        callback: PikaCallback,
+        subscription_id: int,
+        *,
+        auto_ack: bool = True,
+    ) -> Future[str]:
+        """
+        Create and then subscribe to a temporary queue. Thread-safe.
+
+        Args:
+            queue: The queue to listen for messages on, may be empty
+            callback: The function to call when receiving messages on this queue
+            subscription_id: Internal ID representing this subscription.
+            auto_ack: Should this subscription auto-acknowledge messages?
+
+        Returns:
+            A Future representing the resulting queue name.
+            It will be set upon subscription success.
+        """
+
+        if not self._connection:
+            raise RuntimeError("Cannot subscribe to unstarted connection")
+
+        result: Future[str] = Future()
+
+        def _declare_subscribe_queue_in_thread():
+            try:
+                if result.set_running_or_notify_cancel():
+                    assert (
+                        subscription_id not in self._subscriptions
+                    ), f"Subscription request {subscription_id} rejected due to existing subscription {self._subscriptions[subscription_id]}"
+                    temporary_queue_name = (
+                        self._get_shared_channel()
+                        .queue_declare(
+                            queue, auto_delete=True, exclusive=True, durable=False
+                        )
+                        .method.queue
+                    )
+                    temporary_subscription = _PikaSubscription(
+                        arguments={},
+                        auto_ack=auto_ack,
+                        destination=temporary_queue_name,
+                        kind=_PikaSubscriptionKind.DIRECT,
+                        on_message_callback=callback,
+                        prefetch_count=0,
+                        reconnectable=False,
+                    )
+                    self._add_subscription(subscription_id, temporary_subscription)
+                    result.set_result(temporary_queue_name)
+            except BaseException as e:
+                result.set_exception(e)
+                raise
+
+        self._connection.add_callback_threadsafe(_declare_subscribe_queue_in_thread)
+
         return result
 
     def unsubscribe(self, subscription_id: int) -> Future[None]:

--- a/src/workflows/util/__init__.py
+++ b/src/workflows/util/__init__.py
@@ -2,7 +2,7 @@ import os
 import socket
 
 
-def generate_unique_host_id():
+def generate_unique_host_id() -> str:
     """Generate a unique ID, that is somewhat guaranteed to be unique among all
     instances running at the same time."""
     host = ".".join(reversed(socket.gethostname().split(".")))

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -47,7 +47,10 @@ def revert_classvariables():
 
 
 @pytest.fixture
-def pikatransport(revert_classvariables):
+def pikatransport(revert_classvariables, connection_params):
+    # connection_params is unused here, but implements the fixture skipping
+    # logic following a single test, instead of attempting a connection for
+    # every individual test.
     pt = PikaTransport()
     pt.connect()
     yield pt

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -12,9 +12,8 @@ from unittest import mock
 import pika
 import pytest
 
-import workflows
-import workflows.transport
 import workflows.transport.pika_transport
+from workflows.transport.common_transport import TemporarySubscription
 from workflows.transport.pika_transport import PikaTransport, _PikaThread
 
 
@@ -45,6 +44,14 @@ def revert_classvariables():
 
     PikaTransport.config = config
     PikaTransport.defaults = defaults
+
+
+@pytest.fixture
+def pikatransport(revert_classvariables):
+    pt = PikaTransport()
+    pt.connect()
+    yield pt
+    pt.disconnect()
 
 
 def test_lookup_and_initialize_pika_transport_layer():
@@ -1088,3 +1095,55 @@ def test_pikathread_unsubscribe(test_channel, connection_params):
 
 def test_pikathread_ack():
     pytest.xfail("Not Implemented")
+
+
+def test_full_stack_temporary_queue_roundtrip(pikatransport):
+    known_subscriptions = set()
+    known_queues = set()
+
+    def assert_not_seen_before(ts: TemporarySubscription):
+        assert ts.subscription_id, "Temporary subscription is missing an ID"
+        assert (
+            ts.subscription_id not in known_subscriptions
+        ), "Duplicate subscription ID"
+        assert ts.queue_name, "Temporary queue does not have a name"
+        assert ts.queue_name not in known_queues, "Duplicate temporary queue name"
+        known_subscriptions.add(ts.subscription_id)
+        known_queues.add(ts.queue_name)
+        print(f"Temporary subscription: {ts}")
+
+    replies = Queue()
+
+    def callback(subscription):
+        def _callback(header, message):
+            print(f"Received message for {subscription}: {message}")
+            replies.put((subscription, header, message))
+
+        return _callback
+
+    ts = {}
+    for n, queue_hint in enumerate(
+        ("", "", "hint", "hint", "transient.hint", "transient.hint")
+    ):
+        ts[n] = pikatransport.subscribe_temporary(queue_hint, callback(n))
+        assert_not_seen_before(ts[n])
+        assert queue_hint in ts[n].queue_name
+        assert "transient.transient." not in ts[n].queue_name
+
+    assert replies.empty()
+
+    outstanding_messages = set()
+    for n in range(6):
+        outstanding_messages.add((n, f"message {n}"))
+        pikatransport.send(ts[n].queue_name, f"message {n}")
+
+    try:
+        while outstanding_messages:
+            s, _, m = replies.get(timeout=1.5)
+            if (s, m) not in outstanding_messages:
+                raise RuntimeError(
+                    f"Received unexpected message {m} on subscription {s}"
+                )
+            outstanding_messages.remove((s, m))
+    except Empty:
+        raise RuntimeError(f"Missing replies for {len(outstanding_messages)} messages")

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -1132,6 +1132,8 @@ def test_full_stack_temporary_queue_roundtrip(pikatransport):
         assert_not_seen_before(ts[n])
         assert queue_hint in ts[n].queue_name
         assert "transient.transient." not in ts[n].queue_name
+        if not queue_hint:
+            assert ts[n].queue_name.startswith("amq.gen-")
 
     assert replies.empty()
 


### PR DESCRIPTION
This adds a `subscribe_temporary()` function (with pika and stomp implementations, and full-stack pika tests).

Merging this resolves #105 discussion and closes #100 and closes #95.