### PR TITLE
Upgrade code to Python 3.7+

### DIFF
--- a/.azure-pipelines/flake8-validation.py
+++ b/.azure-pipelines/flake8-validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 

--- a/.azure-pipelines/syntax-validation.py
+++ b/.azure-pipelines/syntax-validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import os
 import sys

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,21 @@
 repos:
+# Syntax validation and some basic sanity checks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-merge-conflict
+  - id: check-ast
+  - id: check-json
+  - id: check-added-large-files
+    args: ['--maxkb=200']
+  - id: check-yaml
+
+# Upgrade type hints to Python 3.7+ standard
+- repo: https://github.com/snok/pep585-upgrade
+  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
+  hooks:
+  - id: upgrade-type-hints
+    args: [ '--futures=true' ]
 
 # Automatically sort imports
 - repo: https://github.com/PyCQA/isort
@@ -20,23 +37,7 @@ repos:
   - id: flake8
     additional_dependencies: ['flake8-comprehensions==3.5.0']
 
-# Syntax validation and some basic sanity checks
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
-  hooks:
-  - id: check-merge-conflict
-  - id: check-ast
-  - id: check-json
-  - id: check-added-large-files
-    args: ['--maxkb=200']
-  - id: check-yaml
-
 # Type checking
-- repo: https://github.com/snok/pep585-upgrade
-  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
-  hooks:
-  - id: upgrade-type-hints
-    args: [ '--futures=true' ]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.910
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,6 @@ repos:
     args: ['--maxkb=200']
   - id: check-yaml
 
-# Upgrade type hints to Python 3.7+ standard
-# Need to wait on https://github.com/snok/pep585-upgrade/issues/26
-#- repo: https://github.com/snok/pep585-upgrade
-#  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
-#  hooks:
-#  - id: upgrade-type-hints
-#    args: [ '--futures=true' ]
-
 # Automatically sort imports
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,12 @@ repos:
   - id: check-yaml
 
 # Upgrade type hints to Python 3.7+ standard
-- repo: https://github.com/snok/pep585-upgrade
-  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
-  hooks:
-  - id: upgrade-type-hints
-    args: [ '--futures=true' ]
+# Need to wait on https://github.com/snok/pep585-upgrade/issues/26
+#- repo: https://github.com/snok/pep585-upgrade
+#  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
+#  hooks:
+#  - id: upgrade-type-hints
+#    args: [ '--futures=true' ]
 
 # Automatically sort imports
 - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
   - id: check-yaml
 
 # Type checking
+- repo: https://github.com/snok/pep585-upgrade
+  rev: cc5678ebc6ddf2f1fa17c34d212627474c988e86  # v1.0.1
+  hooks:
+  - id: upgrade-type-hints
+    args: [ '--futures=true' ]
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.910
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
   rev: 5.9.3
   hooks:
   - id: isort
+    args: ['-a', 'from __future__ import annotations']
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
   hooks:
   - id: check-merge-conflict
   - id: check-ast
+    fail_fast: True
   - id: check-json
   - id: check-added-large-files
     args: ['--maxkb=200']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,17 @@ repos:
   rev: 5.9.3
   hooks:
   - id: isort
-    args: ['-a', 'from __future__ import annotations']
+    args: [
+           '-a', 'from __future__ import annotations',        # 3.7-3.11
+           '--rm', 'from __future__ import absolute_import',  # -3.0
+           '--rm', 'from __future__ import division',         # -3.0
+           '--rm', 'from __future__ import generator_stop',   # -3.7
+           '--rm', 'from __future__ import generators',       # -2.3
+           '--rm', 'from __future__ import nested_scopes',    # -2.2
+           '--rm', 'from __future__ import print_function',   # -3.0
+           '--rm', 'from __future__ import unicode_literals', # -3.0
+           '--rm', 'from __future__ import with_statement',   # -2.6
+          ]
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 import setuptools
 
 if __name__ == "__main__":

--- a/src/workflows/__init__.py
+++ b/src/workflows/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __version__ = "2.18"
 
 

--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from optparse import SUPPRESS_HELP, OptionParser
 
 import workflows

--- a/src/workflows/contrib/status_monitor.py
+++ b/src/workflows/contrib/status_monitor.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import curses
 import threading
 import time
-from typing import Any
+from typing import Any, Dict
 
 import workflows.transport
 from workflows.services.common_service import CommonService
@@ -19,7 +17,7 @@ class Monitor:  # pragma: no cover
     shutdown = False
     """Set to true to end the main loop and shut down the service monitor."""
 
-    cards: dict[Any, Any] = {}
+    cards: Dict[Any, Any] = {}
     """Register card shown for seen services"""
 
     border_chars = ()

--- a/src/workflows/contrib/status_monitor.py
+++ b/src/workflows/contrib/status_monitor.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import curses
 import threading
 import time
-from typing import Any, Dict
+from typing import Any
 
 import workflows.transport
 from workflows.services.common_service import CommonService
@@ -17,7 +19,7 @@ class Monitor:  # pragma: no cover
     shutdown = False
     """Set to true to end the main loop and shut down the service monitor."""
 
-    cards: Dict[Any, Any] = {}
+    cards: dict[Any, Any] = {}
     """Register card shown for seen services"""
 
     border_chars = ()

--- a/src/workflows/contrib/status_monitor.py
+++ b/src/workflows/contrib/status_monitor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import curses
 import threading
 import time

--- a/src/workflows/frontend/__init__.py
+++ b/src/workflows/frontend/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import multiprocessing
 import threading

--- a/src/workflows/frontend/utilization.py
+++ b/src/workflows/frontend/utilization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from workflows.services.common_service import CommonService

--- a/src/workflows/logging.py
+++ b/src/workflows/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import linecache
 import logging
 import os.path

--- a/src/workflows/recipe/__init__.py
+++ b/src/workflows/recipe/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from workflows.recipe.recipe import Recipe
 from workflows.recipe.validate import validate_recipe
 from workflows.recipe.wrapper import RecipeWrapper

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 import json
 import string
-from typing import Any, Dict
+from typing import Any
 
 import workflows
 
@@ -13,7 +15,7 @@ class Recipe:
     A recipe describes how all involved services are connected together, how
     data should be passed and how errors should be handled."""
 
-    recipe: Dict[Any, Any] = {}
+    recipe: dict[Any, Any] = {}
     """The processing recipe is encoded in this dictionary."""
     # TODO: Describe format
 

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import copy
 import json
 import string
-from typing import Any
+from typing import Any, Dict
 
 import workflows
 
@@ -15,7 +13,7 @@ class Recipe:
     A recipe describes how all involved services are connected together, how
     data should be passed and how errors should be handled."""
 
-    recipe: dict[Any, Any] = {}
+    recipe: Dict[Any, Any] = {}
     """The processing recipe is encoded in this dictionary."""
     # TODO: Describe format
 

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import json
 import string

--- a/src/workflows/recipe/validate.py
+++ b/src/workflows/recipe/validate.py
@@ -15,6 +15,8 @@ Example of how this could be used in a .pre-commit-config.yaml file:
 ```
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging

--- a/src/workflows/recipe/wrapper.py
+++ b/src/workflows/recipe/wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 

--- a/src/workflows/services/__init__.py
+++ b/src/workflows/services/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pkg_resources
 
 

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import enum
 import itertools
@@ -5,7 +7,7 @@ import logging
 import queue
 import threading
 import time
-from typing import Any, Dict
+from typing import Any
 
 import workflows
 import workflows.logging
@@ -126,7 +128,7 @@ class CommonService:
 
     # Any keyword arguments set on service invocation
 
-    start_kwargs: Dict[Any, Any] = {}
+    start_kwargs: dict[Any, Any] = {}
 
     # Not so overrideable functions ---------------------------------------------
 

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 import enum
 import itertools
@@ -7,7 +5,7 @@ import logging
 import queue
 import threading
 import time
-from typing import Any
+from typing import Any, Dict
 
 import workflows
 import workflows.logging
@@ -128,7 +126,7 @@ class CommonService:
 
     # Any keyword arguments set on service invocation
 
-    start_kwargs: dict[Any, Any] = {}
+    start_kwargs: Dict[Any, Any] = {}
 
     # Not so overrideable functions ---------------------------------------------
 

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import enum
 import itertools

--- a/src/workflows/services/sample_consumer.py
+++ b/src/workflows/services/sample_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import time
 

--- a/src/workflows/services/sample_producer.py
+++ b/src/workflows/services/sample_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from workflows.services.common_service import CommonService

--- a/src/workflows/services/sample_transaction.py
+++ b/src/workflows/services/sample_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import time
 

--- a/src/workflows/services/sample_transaction.py
+++ b/src/workflows/services/sample_transaction.py
@@ -40,7 +40,7 @@ class SampleTxn(CommonService):
         assert header["message-id"]
 
         txn = self._transport.transaction_begin()
-        self.log.info(" 1. Txn: {}".format(str(txn)))
+        self.log.info(f" 1. Txn: {txn}")
         if self.crashpoint():
             self._transport.transaction_abort(txn)
             self.log.info("---  Abort  ---")

--- a/src/workflows/transport/__init__.py
+++ b/src/workflows/transport/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import optparse
 from typing import Union

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import decimal
 import logging
-from typing import Any, Callable, Dict, Mapping, NamedTuple, Optional, Set
+from typing import Any, Callable, Mapping, NamedTuple
 
 import workflows
 
@@ -19,9 +19,9 @@ class CommonTransport:
     subscriptions and transactions."""
 
     __callback_interceptor = None
-    __subscriptions: Dict[int, Dict[str, Any]] = {}
+    __subscriptions: dict[int, dict[str, Any]] = {}
     __subscription_id: int = 0
-    __transactions: Set[int] = set()
+    __transactions: set[int] = set()
     __transaction_id: int = 0
 
     log = logging.getLogger("workflows.transport")
@@ -84,7 +84,7 @@ class CommonTransport:
         return self.__subscription_id
 
     def subscribe_temporary(
-        self, channel_hint: Optional[str], callback: MessageCallback, **kwargs
+        self, channel_hint: str | None, callback: MessageCallback, **kwargs
     ) -> TemporarySubscription:
         """Listen to a new queue that is specifically created for this connection,
         and has a limited lifetime. Notify for messages via callback function.
@@ -287,7 +287,7 @@ class CommonTransport:
         """
         self._broadcast(destination, message, **kwargs)
 
-    def ack(self, message, subscription_id: Optional[int] = None, **kwargs):
+    def ack(self, message, subscription_id: int | None = None, **kwargs):
         """Acknowledge receipt of a message. This only makes sense when the
         'acknowledgement' flag was set for the relevant subscription.
         :param message: ID of the message to be acknowledged, OR a dictionary
@@ -314,7 +314,7 @@ class CommonTransport:
         )
         self._ack(message_id, subscription_id=subscription_id, **kwargs)
 
-    def nack(self, message, subscription_id: Optional[int] = None, **kwargs):
+    def nack(self, message, subscription_id: int | None = None, **kwargs):
         """Reject receipt of a message. This only makes sense when the
         'acknowledgement' flag was set for the relevant subscription.
         :param message: ID of the message to be rejected, OR a dictionary
@@ -341,7 +341,7 @@ class CommonTransport:
         )
         self._nack(message_id, subscription_id=subscription_id, **kwargs)
 
-    def transaction_begin(self, subscription_id: Optional[int] = None, **kwargs) -> int:
+    def transaction_begin(self, subscription_id: int | None = None, **kwargs) -> int:
         """Start a new transaction.
         :param **kwargs: Further parameters for the transport layer.
         :return: A transaction ID that can be passed to other functions.
@@ -418,7 +418,7 @@ class CommonTransport:
     def _subscribe_temporary(
         self,
         sub_id: int,
-        channel_hint: Optional[str],
+        channel_hint: str | None,
         callback: MessageCallback,
         **kwargs,
     ) -> str:
@@ -486,7 +486,7 @@ class CommonTransport:
         raise NotImplementedError("Transport interface not implemented")
 
     def _transaction_begin(
-        self, transaction_id: int, *, subscription_id: Optional[int] = None, **kwargs
+        self, transaction_id: int, *, subscription_id: int | None = None, **kwargs
     ) -> None:
         """Start a new transaction.
         :param transaction_id: ID for this transaction in the transport layer.

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import decimal
 import logging
-from typing import Any, Callable, Dict, Mapping, NamedTuple, Optional, Set
+from collections.abc import Mapping
+from typing import Any, Callable, NamedTuple, Optional
 
 import workflows
 
@@ -19,9 +20,9 @@ class CommonTransport:
     subscriptions and transactions."""
 
     __callback_interceptor = None
-    __subscriptions: Dict[int, Dict[str, Any]] = {}
+    __subscriptions: dict[int, dict[str, Any]] = {}
     __subscription_id: int = 0
-    __transactions: Set[int] = set()
+    __transactions: set[int] = set()
     __transaction_id: int = 0
 
     log = logging.getLogger("workflows.transport")

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import decimal
 import logging
-from collections.abc import Mapping
-from typing import Any, Callable, NamedTuple, Optional
+from typing import Any, Callable, Dict, Mapping, NamedTuple, Optional, Set
 
 import workflows
 
@@ -20,9 +19,9 @@ class CommonTransport:
     subscriptions and transactions."""
 
     __callback_interceptor = None
-    __subscriptions: dict[int, dict[str, Any]] = {}
+    __subscriptions: Dict[int, Dict[str, Any]] = {}
     __subscription_id: int = 0
-    __transactions: set[int] = set()
+    __transactions: Set[int] = set()
     __transaction_id: int = 0
 
     log = logging.getLogger("workflows.transport")

--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import decimal
 import logging
-from typing import Any, Callable, Mapping, NamedTuple
+from typing import Any, Callable, Dict, Mapping, NamedTuple, Optional, Set
 
 import workflows
 
@@ -19,9 +19,9 @@ class CommonTransport:
     subscriptions and transactions."""
 
     __callback_interceptor = None
-    __subscriptions: dict[int, dict[str, Any]] = {}
+    __subscriptions: Dict[int, Dict[str, Any]] = {}
     __subscription_id: int = 0
-    __transactions: set[int] = set()
+    __transactions: Set[int] = set()
     __transaction_id: int = 0
 
     log = logging.getLogger("workflows.transport")
@@ -84,7 +84,7 @@ class CommonTransport:
         return self.__subscription_id
 
     def subscribe_temporary(
-        self, channel_hint: str | None, callback: MessageCallback, **kwargs
+        self, channel_hint: Optional[str], callback: MessageCallback, **kwargs
     ) -> TemporarySubscription:
         """Listen to a new queue that is specifically created for this connection,
         and has a limited lifetime. Notify for messages via callback function.
@@ -287,7 +287,7 @@ class CommonTransport:
         """
         self._broadcast(destination, message, **kwargs)
 
-    def ack(self, message, subscription_id: int | None = None, **kwargs):
+    def ack(self, message, subscription_id: Optional[int] = None, **kwargs):
         """Acknowledge receipt of a message. This only makes sense when the
         'acknowledgement' flag was set for the relevant subscription.
         :param message: ID of the message to be acknowledged, OR a dictionary
@@ -314,7 +314,7 @@ class CommonTransport:
         )
         self._ack(message_id, subscription_id=subscription_id, **kwargs)
 
-    def nack(self, message, subscription_id: int | None = None, **kwargs):
+    def nack(self, message, subscription_id: Optional[int] = None, **kwargs):
         """Reject receipt of a message. This only makes sense when the
         'acknowledgement' flag was set for the relevant subscription.
         :param message: ID of the message to be rejected, OR a dictionary
@@ -341,7 +341,7 @@ class CommonTransport:
         )
         self._nack(message_id, subscription_id=subscription_id, **kwargs)
 
-    def transaction_begin(self, subscription_id: int | None = None, **kwargs) -> int:
+    def transaction_begin(self, subscription_id: Optional[int] = None, **kwargs) -> int:
         """Start a new transaction.
         :param **kwargs: Further parameters for the transport layer.
         :return: A transaction ID that can be passed to other functions.
@@ -418,7 +418,7 @@ class CommonTransport:
     def _subscribe_temporary(
         self,
         sub_id: int,
-        channel_hint: str | None,
+        channel_hint: Optional[str],
         callback: MessageCallback,
         **kwargs,
     ) -> str:
@@ -486,7 +486,7 @@ class CommonTransport:
         raise NotImplementedError("Transport interface not implemented")
 
     def _transaction_begin(
-        self, transaction_id: int, *, subscription_id: int | None = None, **kwargs
+        self, transaction_id: int, *, subscription_id: Optional[int] = None, **kwargs
     ) -> None:
         """Start a new transaction.
         :param transaction_id: ID for this transaction in the transport layer.

--- a/src/workflows/transport/offline_transport.py
+++ b/src/workflows/transport/offline_transport.py
@@ -1,11 +1,14 @@
-# A workflows transport that doesn't actually transport anything
+from __future__ import annotations
 
 import json
 import logging
 import pprint
-from typing import Any, Dict
+from typing import Any
 
 from workflows.transport.common_transport import CommonTransport, json_serializer
+
+# A workflows transport that doesn't actually transport anything
+
 
 _offlog = logging.getLogger("workflows.transport.offline_transport")
 
@@ -14,9 +17,9 @@ class OfflineTransport(CommonTransport):
     """Abstraction layer for messaging infrastructure. Here we.. do nothing."""
 
     # Add for compatibility
-    defaults: Dict[Any, Any] = {}
+    defaults: dict[Any, Any] = {}
     # Effective configuration
-    config: Dict[Any, Any] = {}
+    config: dict[Any, Any] = {}
 
     def __init__(self):
         self._connected = False

--- a/src/workflows/transport/offline_transport.py
+++ b/src/workflows/transport/offline_transport.py
@@ -1,14 +1,11 @@
-from __future__ import annotations
+# A workflows transport that doesn't actually transport anything
 
 import json
 import logging
 import pprint
-from typing import Any
+from typing import Any, Dict
 
 from workflows.transport.common_transport import CommonTransport, json_serializer
-
-# A workflows transport that doesn't actually transport anything
-
 
 _offlog = logging.getLogger("workflows.transport.offline_transport")
 
@@ -17,9 +14,9 @@ class OfflineTransport(CommonTransport):
     """Abstraction layer for messaging infrastructure. Here we.. do nothing."""
 
     # Add for compatibility
-    defaults: dict[Any, Any] = {}
+    defaults: Dict[Any, Any] = {}
     # Effective configuration
-    config: dict[Any, Any] = {}
+    config: Dict[Any, Any] = {}
 
     def __init__(self):
         self._connected = False

--- a/src/workflows/transport/offline_transport.py
+++ b/src/workflows/transport/offline_transport.py
@@ -1,5 +1,7 @@
 # A workflows transport that doesn't actually transport anything
 
+from __future__ import annotations
+
 import json
 import logging
 import pprint

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -10,10 +10,9 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Iterable
 from concurrent.futures import Future
 from enum import Enum, auto
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import pika.exceptions
 from bidict import bidict
@@ -59,7 +58,7 @@ class PikaTransport(CommonTransport):
     }
 
     # Effective configuration
-    config: dict[Any, Any] = {}
+    config: Dict[Any, Any] = {}
 
     def __init__(self):
         self._channel = None
@@ -237,7 +236,7 @@ class PikaTransport(CommonTransport):
             callback=set_parameter,
         )
 
-    def _generate_connection_parameters(self) -> list[pika.ConnectionParameters]:
+    def _generate_connection_parameters(self) -> List[pika.ConnectionParameters]:
         username = self.config.get("--rabbit-user", self.defaults.get("--rabbit-user"))
         password = self.config.get("--rabbit-pass", self.defaults.get("--rabbit-pass"))
         credentials = pika.PlainCredentials(username, password)
@@ -717,7 +716,7 @@ class _PikaSubscription:
         reconnectable: Are we allowed to reconnect to this subscription
     """
 
-    arguments: dict[str, Any]
+    arguments: Dict[str, Any]
     auto_ack: bool
     destination: str
     kind: _PikaSubscriptionKind
@@ -756,7 +755,7 @@ class _PikaThread(threading.Thread):
         # Internal store of subscriptions, to resubscribe if necessary. Keys are
         # unique and auto-generated, and known as subscription IDs or consumer tags
         # (strictly: pika/AMQP consumer tags are strings, not integers)
-        self._subscriptions: dict[int, _PikaSubscription] = {}
+        self._subscriptions: Dict[int, _PikaSubscription] = {}
         # The pika connection object
         self._connection: Optional[pika.BlockingConnection] = None
         # Index of per-subscription channels.
@@ -764,7 +763,7 @@ class _PikaThread(threading.Thread):
         # Bidirectional index of all ongoing transactions. May include the shared channel
         self._transaction_on_channel: bidict[BlockingChannel, int] = bidict()
         # Information on whether a channel has uncommitted messages
-        self._channel_has_active_tx: dict[BlockingChannel, bool] = {}
+        self._channel_has_active_tx: Dict[BlockingChannel, bool] = {}
         # A common, shared channel, used for sending messages outside of transactions.
         self._pika_shared_channel: Optional[BlockingChannel]
         # Are we allowed to reconnect. Can only be turned off, never on
@@ -772,7 +771,7 @@ class _PikaThread(threading.Thread):
         # Our list of connection parameters, so we know where to connect to
         self._connection_parameters = list(connection_parameters)
         # If we failed with an unexpected exception
-        self._exc_info: Optional[tuple[Any, Any, Any]] = None
+        self._exc_info: Optional[Tuple[Any, Any, Any]] = None
         self._reconnection_attempt_limit = reconnection_attempts
         # General bookkeeping events
 

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -10,9 +10,10 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Iterable
 from concurrent.futures import Future
 from enum import Enum, auto
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Union
 
 import pika.exceptions
 from bidict import bidict
@@ -58,7 +59,7 @@ class PikaTransport(CommonTransport):
     }
 
     # Effective configuration
-    config: Dict[Any, Any] = {}
+    config: dict[Any, Any] = {}
 
     def __init__(self):
         self._channel = None
@@ -236,7 +237,7 @@ class PikaTransport(CommonTransport):
             callback=set_parameter,
         )
 
-    def _generate_connection_parameters(self) -> List[pika.ConnectionParameters]:
+    def _generate_connection_parameters(self) -> list[pika.ConnectionParameters]:
         username = self.config.get("--rabbit-user", self.defaults.get("--rabbit-user"))
         password = self.config.get("--rabbit-pass", self.defaults.get("--rabbit-pass"))
         credentials = pika.PlainCredentials(username, password)
@@ -716,7 +717,7 @@ class _PikaSubscription:
         reconnectable: Are we allowed to reconnect to this subscription
     """
 
-    arguments: Dict[str, Any]
+    arguments: dict[str, Any]
     auto_ack: bool
     destination: str
     kind: _PikaSubscriptionKind
@@ -755,7 +756,7 @@ class _PikaThread(threading.Thread):
         # Internal store of subscriptions, to resubscribe if necessary. Keys are
         # unique and auto-generated, and known as subscription IDs or consumer tags
         # (strictly: pika/AMQP consumer tags are strings, not integers)
-        self._subscriptions: Dict[int, _PikaSubscription] = {}
+        self._subscriptions: dict[int, _PikaSubscription] = {}
         # The pika connection object
         self._connection: Optional[pika.BlockingConnection] = None
         # Index of per-subscription channels.
@@ -763,7 +764,7 @@ class _PikaThread(threading.Thread):
         # Bidirectional index of all ongoing transactions. May include the shared channel
         self._transaction_on_channel: bidict[BlockingChannel, int] = bidict()
         # Information on whether a channel has uncommitted messages
-        self._channel_has_active_tx: Dict[BlockingChannel, bool] = {}
+        self._channel_has_active_tx: dict[BlockingChannel, bool] = {}
         # A common, shared channel, used for sending messages outside of transactions.
         self._pika_shared_channel: Optional[BlockingChannel]
         # Are we allowed to reconnect. Can only be turned off, never on
@@ -771,7 +772,7 @@ class _PikaThread(threading.Thread):
         # Our list of connection parameters, so we know where to connect to
         self._connection_parameters = list(connection_parameters)
         # If we failed with an unexpected exception
-        self._exc_info: Optional[Tuple[Any, Any, Any]] = None
+        self._exc_info: Optional[tuple[Any, Any, Any]] = None
         self._reconnection_attempt_limit = reconnection_attempts
         # General bookkeeping events
 

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -12,7 +12,7 @@ import time
 import uuid
 from concurrent.futures import Future
 from enum import Enum, auto
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable
 
 import pika.exceptions
 from bidict import bidict
@@ -58,7 +58,7 @@ class PikaTransport(CommonTransport):
     }
 
     # Effective configuration
-    config: Dict[Any, Any] = {}
+    config: dict[Any, Any] = {}
 
     def __init__(self):
         self._channel = None
@@ -236,7 +236,7 @@ class PikaTransport(CommonTransport):
             callback=set_parameter,
         )
 
-    def _generate_connection_parameters(self) -> List[pika.ConnectionParameters]:
+    def _generate_connection_parameters(self) -> list[pika.ConnectionParameters]:
         username = self.config.get("--rabbit-user", self.defaults.get("--rabbit-user"))
         password = self.config.get("--rabbit-pass", self.defaults.get("--rabbit-pass"))
         credentials = pika.PlainCredentials(username, password)
@@ -435,7 +435,7 @@ class PikaTransport(CommonTransport):
     def _subscribe_temporary(
         self,
         sub_id: int,
-        channel_hint: Optional[str],
+        channel_hint: str | None,
         callback: MessageCallback,
         *,
         acknowledgement: bool = False,
@@ -489,7 +489,7 @@ class PikaTransport(CommonTransport):
         headers=None,
         delay=None,
         expiration=None,
-        transaction: Optional[int] = None,
+        transaction: int | None = None,
         **kwargs,
     ):
         """
@@ -532,8 +532,8 @@ class PikaTransport(CommonTransport):
         message,
         headers=None,
         delay=None,
-        expiration: Optional[int] = None,
-        transaction: Optional[int] = None,
+        expiration: int | None = None,
+        transaction: int | None = None,
         **kwargs,
     ):
         """Send a message to a fanout exchange.
@@ -571,7 +571,7 @@ class PikaTransport(CommonTransport):
         ).result()
 
     def _transaction_begin(
-        self, transaction_id: int, *, subscription_id: Optional[int] = None, **kwargs
+        self, transaction_id: int, *, subscription_id: int | None = None, **kwargs
     ) -> None:
         """Start a new transaction.
         :param transaction_id: ID for this transaction in the transport layer.
@@ -716,13 +716,13 @@ class _PikaSubscription:
         reconnectable: Are we allowed to reconnect to this subscription
     """
 
-    arguments: Dict[str, Any]
+    arguments: dict[str, Any]
     auto_ack: bool
     destination: str
     kind: _PikaSubscriptionKind
     on_message_callback: PikaCallback = dataclasses.field(repr=False)
     prefetch_count: int
-    queue: Optional[str] = dataclasses.field(init=False, default=None)
+    queue: str | None = dataclasses.field(init=False, default=None)
     reconnectable: bool
 
 
@@ -755,23 +755,23 @@ class _PikaThread(threading.Thread):
         # Internal store of subscriptions, to resubscribe if necessary. Keys are
         # unique and auto-generated, and known as subscription IDs or consumer tags
         # (strictly: pika/AMQP consumer tags are strings, not integers)
-        self._subscriptions: Dict[int, _PikaSubscription] = {}
+        self._subscriptions: dict[int, _PikaSubscription] = {}
         # The pika connection object
-        self._connection: Optional[pika.BlockingConnection] = None
+        self._connection: pika.BlockingConnection | None = None
         # Index of per-subscription channels.
         self._pika_channels: bidict[int, BlockingChannel] = bidict()
         # Bidirectional index of all ongoing transactions. May include the shared channel
         self._transaction_on_channel: bidict[BlockingChannel, int] = bidict()
         # Information on whether a channel has uncommitted messages
-        self._channel_has_active_tx: Dict[BlockingChannel, bool] = {}
+        self._channel_has_active_tx: dict[BlockingChannel, bool] = {}
         # A common, shared channel, used for sending messages outside of transactions.
-        self._pika_shared_channel: Optional[BlockingChannel]
+        self._pika_shared_channel: BlockingChannel | None
         # Are we allowed to reconnect. Can only be turned off, never on
         self._reconnection_allowed: bool = True
         # Our list of connection parameters, so we know where to connect to
         self._connection_parameters = list(connection_parameters)
         # If we failed with an unexpected exception
-        self._exc_info: Optional[Tuple[Any, Any, Any]] = None
+        self._exc_info: tuple[Any, Any, Any] | None = None
         self._reconnection_attempt_limit = reconnection_attempts
         # General bookkeeping events
 
@@ -815,9 +815,7 @@ class _PikaThread(threading.Thread):
         except pika.exceptions.ConnectionWrongStateError:
             pass
 
-    def join(
-        self, timeout: Optional[float] = None, *, re_raise: bool = False, stop=False
-    ):
+    def join(self, timeout: float | None = None, *, re_raise: bool = False, stop=False):
         """Wait until the thread terminates.
 
         Args:
@@ -1049,10 +1047,10 @@ class _PikaThread(threading.Thread):
         self,
         exchange: str,
         routing_key: str,
-        body: Union[str, bytes],
+        body: str | bytes,
         properties: pika.spec.BasicProperties = None,
         mandatory: bool = True,
-        transaction_id: Optional[int] = None,
+        transaction_id: int | None = None,
     ) -> Future[None]:
         """Send a message. Thread-safe."""
 
@@ -1090,7 +1088,7 @@ class _PikaThread(threading.Thread):
         subscription_id: int,
         *,
         multiple=False,
-        transaction_id: Optional[int],
+        transaction_id: int | None,
     ):
         if subscription_id not in self._subscriptions:
             raise KeyError(f"Could not find subscription {subscription_id} to ACK")
@@ -1129,7 +1127,7 @@ class _PikaThread(threading.Thread):
         *,
         multiple=False,
         requeue=True,
-        transaction_id: Optional[int],
+        transaction_id: int | None,
     ):
         if subscription_id not in self._subscriptions:
             raise KeyError(f"Could not find subscription {subscription_id} to NACK")
@@ -1162,7 +1160,7 @@ class _PikaThread(threading.Thread):
             )
 
     def tx_select(
-        self, transaction_id: int, subscription_id: Optional[int]
+        self, transaction_id: int, subscription_id: int | None
     ) -> Future[None]:
         """Set a channel to transaction mode. Thread-safe.
         :param transaction_id: ID for this transaction in the transport layer.

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -12,7 +12,7 @@ import time
 import uuid
 from concurrent.futures import Future
 from enum import Enum, auto
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import pika.exceptions
 from bidict import bidict
@@ -58,7 +58,7 @@ class PikaTransport(CommonTransport):
     }
 
     # Effective configuration
-    config: dict[Any, Any] = {}
+    config: Dict[Any, Any] = {}
 
     def __init__(self):
         self._channel = None
@@ -236,7 +236,7 @@ class PikaTransport(CommonTransport):
             callback=set_parameter,
         )
 
-    def _generate_connection_parameters(self) -> list[pika.ConnectionParameters]:
+    def _generate_connection_parameters(self) -> List[pika.ConnectionParameters]:
         username = self.config.get("--rabbit-user", self.defaults.get("--rabbit-user"))
         password = self.config.get("--rabbit-pass", self.defaults.get("--rabbit-pass"))
         credentials = pika.PlainCredentials(username, password)
@@ -435,7 +435,7 @@ class PikaTransport(CommonTransport):
     def _subscribe_temporary(
         self,
         sub_id: int,
-        channel_hint: str | None,
+        channel_hint: Optional[str],
         callback: MessageCallback,
         *,
         acknowledgement: bool = False,
@@ -489,7 +489,7 @@ class PikaTransport(CommonTransport):
         headers=None,
         delay=None,
         expiration=None,
-        transaction: int | None = None,
+        transaction: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -532,8 +532,8 @@ class PikaTransport(CommonTransport):
         message,
         headers=None,
         delay=None,
-        expiration: int | None = None,
-        transaction: int | None = None,
+        expiration: Optional[int] = None,
+        transaction: Optional[int] = None,
         **kwargs,
     ):
         """Send a message to a fanout exchange.
@@ -571,7 +571,7 @@ class PikaTransport(CommonTransport):
         ).result()
 
     def _transaction_begin(
-        self, transaction_id: int, *, subscription_id: int | None = None, **kwargs
+        self, transaction_id: int, *, subscription_id: Optional[int] = None, **kwargs
     ) -> None:
         """Start a new transaction.
         :param transaction_id: ID for this transaction in the transport layer.
@@ -716,13 +716,13 @@ class _PikaSubscription:
         reconnectable: Are we allowed to reconnect to this subscription
     """
 
-    arguments: dict[str, Any]
+    arguments: Dict[str, Any]
     auto_ack: bool
     destination: str
     kind: _PikaSubscriptionKind
     on_message_callback: PikaCallback = dataclasses.field(repr=False)
     prefetch_count: int
-    queue: str | None = dataclasses.field(init=False, default=None)
+    queue: Optional[str] = dataclasses.field(init=False, default=None)
     reconnectable: bool
 
 
@@ -755,23 +755,23 @@ class _PikaThread(threading.Thread):
         # Internal store of subscriptions, to resubscribe if necessary. Keys are
         # unique and auto-generated, and known as subscription IDs or consumer tags
         # (strictly: pika/AMQP consumer tags are strings, not integers)
-        self._subscriptions: dict[int, _PikaSubscription] = {}
+        self._subscriptions: Dict[int, _PikaSubscription] = {}
         # The pika connection object
-        self._connection: pika.BlockingConnection | None = None
+        self._connection: Optional[pika.BlockingConnection] = None
         # Index of per-subscription channels.
         self._pika_channels: bidict[int, BlockingChannel] = bidict()
         # Bidirectional index of all ongoing transactions. May include the shared channel
         self._transaction_on_channel: bidict[BlockingChannel, int] = bidict()
         # Information on whether a channel has uncommitted messages
-        self._channel_has_active_tx: dict[BlockingChannel, bool] = {}
+        self._channel_has_active_tx: Dict[BlockingChannel, bool] = {}
         # A common, shared channel, used for sending messages outside of transactions.
-        self._pika_shared_channel: BlockingChannel | None
+        self._pika_shared_channel: Optional[BlockingChannel]
         # Are we allowed to reconnect. Can only be turned off, never on
         self._reconnection_allowed: bool = True
         # Our list of connection parameters, so we know where to connect to
         self._connection_parameters = list(connection_parameters)
         # If we failed with an unexpected exception
-        self._exc_info: tuple[Any, Any, Any] | None = None
+        self._exc_info: Optional[Tuple[Any, Any, Any]] = None
         self._reconnection_attempt_limit = reconnection_attempts
         # General bookkeeping events
 
@@ -815,7 +815,9 @@ class _PikaThread(threading.Thread):
         except pika.exceptions.ConnectionWrongStateError:
             pass
 
-    def join(self, timeout: float | None = None, *, re_raise: bool = False, stop=False):
+    def join(
+        self, timeout: Optional[float] = None, *, re_raise: bool = False, stop=False
+    ):
         """Wait until the thread terminates.
 
         Args:
@@ -1047,10 +1049,10 @@ class _PikaThread(threading.Thread):
         self,
         exchange: str,
         routing_key: str,
-        body: str | bytes,
+        body: Union[str, bytes],
         properties: pika.spec.BasicProperties = None,
         mandatory: bool = True,
-        transaction_id: int | None = None,
+        transaction_id: Optional[int] = None,
     ) -> Future[None]:
         """Send a message. Thread-safe."""
 
@@ -1088,7 +1090,7 @@ class _PikaThread(threading.Thread):
         subscription_id: int,
         *,
         multiple=False,
-        transaction_id: int | None,
+        transaction_id: Optional[int],
     ):
         if subscription_id not in self._subscriptions:
             raise KeyError(f"Could not find subscription {subscription_id} to ACK")
@@ -1127,7 +1129,7 @@ class _PikaThread(threading.Thread):
         *,
         multiple=False,
         requeue=True,
-        transaction_id: int | None,
+        transaction_id: Optional[int],
     ):
         if subscription_id not in self._subscriptions:
             raise KeyError(f"Could not find subscription {subscription_id} to NACK")
@@ -1160,7 +1162,7 @@ class _PikaThread(threading.Thread):
             )
 
     def tx_select(
-        self, transaction_id: int, subscription_id: int | None
+        self, transaction_id: int, subscription_id: Optional[int]
     ) -> Future[None]:
         """Set a channel to transaction mode. Thread-safe.
         :param transaction_id: ID for this transaction in the transport layer.

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import configparser
 import json
 import threading
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import stomp
 
@@ -28,7 +30,7 @@ class StompTransport(CommonTransport):
         "--stomp-prfx": "",
     }
     # Effective configuration
-    config: Dict[Any, Any] = {}
+    config: dict[Any, Any] = {}
 
     def __init__(self):
         self._connected = False

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -508,6 +508,4 @@ class StompTransport(CommonTransport):
         if target_function:
             target_function(headers, body)
         else:
-            raise workflows.Error(
-                "Unhandled message {} {}".format(repr(headers), repr(body))
-            )
+            raise workflows.Error(f"Unhandled message {headers!r} {body!r}")

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
 import configparser
 import json
 import threading
 import time
 import uuid
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import stomp
 
@@ -30,7 +28,7 @@ class StompTransport(CommonTransport):
         "--stomp-prfx": "",
     }
     # Effective configuration
-    config: dict[Any, Any] = {}
+    config: Dict[Any, Any] = {}
 
     def __init__(self):
         self._connected = False

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 import json
 import threading

--- a/src/workflows/util/__init__.py
+++ b/src/workflows/util/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import socket
 

--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from marshmallow import fields
 from zocalo.configuration import PluginSchema
 

--- a/tests/contrib/test_start_service.py
+++ b/tests/contrib/test_start_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/contrib/test_status_monitor.py
+++ b/tests/contrib/test_status_monitor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.contrib.status_monitor as status_monitor

--- a/tests/frontend/test_frontend.py
+++ b/tests/frontend/test_frontend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/frontend/test_utilization.py
+++ b/tests/frontend/test_utilization.py
@@ -23,7 +23,7 @@ def about(value, tolerance):
             return not self.__eq__(other)
 
         def __repr__(self):
-            return "<{} +- {}>".format(str(value), str(tolerance))
+            return f"<{value} +- {tolerance}>"
 
     return Comparator()
 

--- a/tests/frontend/test_utilization.py
+++ b/tests/frontend/test_utilization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.frontend.utilization

--- a/tests/recipe/test_recipe.py
+++ b/tests/recipe/test_recipe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/recipe/test_validate.py
+++ b/tests/recipe/test_validate.py
@@ -2,6 +2,8 @@
 Tests the functionality of validate.py with several different recipes which should raise different errors
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from unittest import mock

--- a/tests/recipe/test_wrap_subscription.py
+++ b/tests/recipe/test_wrap_subscription.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows

--- a/tests/recipe/test_wrapped_recipe.py
+++ b/tests/recipe/test_wrapped_recipe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/services/test.py
+++ b/tests/services/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import workflows.services
 
 

--- a/tests/services/test_common_service.py
+++ b/tests/services/test_common_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import queue
 from multiprocessing import Pipe
 from unittest import mock

--- a/tests/services/test_sample_consumer.py
+++ b/tests/services/test_sample_consumer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.services

--- a/tests/services/test_sample_producer.py
+++ b/tests/services/test_sample_producer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.services

--- a/tests/services/test_sample_transaction.py
+++ b/tests/services/test_sample_transaction.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.services

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import workflows
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from unittest import mock

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,7 +25,7 @@ def test_obtain_exception_source():
         assert fp == __file__
         assert os.path.basename(fp) == fn
         assert name == "crashfunction"
-        assert line_number == 15  # this will break if line number in this file changes
+        assert line_number == 17  # this will break if line number in this file changes
         assert line == "print(everything / nothing)"
 
 

--- a/tests/transport/test.py
+++ b/tests/transport/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import workflows.transport
 
 

--- a/tests/transport/test_common.py
+++ b/tests/transport/test_common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/transport/test_offline.py
+++ b/tests/transport/test_offline.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import decimal
 import logging
 from unittest import mock

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import copy
 import inspect

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -92,9 +92,7 @@ port = 1234
 username = someuser
 password = somesecret
 prefix = namespace
-""".encode(
-                "utf-8"
-            )
+""".encode()
         )
         cfgfile.close()
 

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -82,7 +82,7 @@ def test_check_config_file_behaviour(mockstomp):
     cfgfile = tempfile.NamedTemporaryFile(delete=False)
     try:
         cfgfile.write(
-            """
+            b"""
 # An example stomp configuration file
 # Only lines in the [stomp] block will be interpreted
 
@@ -92,7 +92,7 @@ port = 1234
 username = someuser
 password = somesecret
 prefix = namespace
-""".encode()
+"""
         )
         cfgfile.close()
 

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import decimal
 import importlib

--- a/tests/util/test.py
+++ b/tests/util/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import workflows.util
 
 


### PR DESCRIPTION
Workflows already runs with Python 3.7 as minimum version, but with 3.6 now officially gone this is a good opportunity for a code base spring clean.