### PR TITLE
Fix ack/nack logic outside of transaction

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1151,12 +1151,12 @@ class _PikaThread(threading.Thread):
         if transaction_id is None and not self._channel_has_active_tx.get(channel):
             channel_is_transactional = self._channel_is_transactional.get(channel)
 
-            def _ack_callback():
+            def _nack_callback():
                 channel.basic_nack(delivery_tag, multiple=multiple)
                 if channel_is_transactional:
                     channel.tx_commit()
 
-            self._connection.add_callback_threadsafe(_ack_callback)
+            self._connection.add_callback_threadsafe(_nack_callback)
         else:
             # Matching transaction IDs - perfect
             # We are in a transaction so make a note that it is now being used


### PR DESCRIPTION
Track whether a channel is transactional - once a channel has been made transactional, we need a `tx_commit()`
when (n)ack'ing a message outside of an explicit transaction.

Clear internal channel dictionaries on reconnection to avoid memory leaks.