### PR TITLE
RMQ: support for delayed message exchanges

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -526,7 +526,7 @@ class PikaTransport(CommonTransport):
                     "No delayed message exchange set, but transport delay requested"
                 )
             headers["x-delay"] = 1000 * delay
-            exchange = "zocalo"
+            exchange = self._delayed_message_exchange
         else:
             exchange = ""
 

--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -39,7 +39,6 @@ class Pika:
         username = fields.Str(required=True)
         password = fields.Str(required=True)
         vhost = fields.Str(required=True)
-        delayed_message_exchange = fields.Str(required=False)
 
     @staticmethod
     def activate(configuration):
@@ -49,9 +48,7 @@ class Pika:
             ("username", "--rabbit-user"),
             ("password", "--rabbit-pass"),
             ("vhost", "--rabbit-vhost"),
-            ("delayed_message_exchange", "--rabbit-delayed-message-exchange"),
         ]:
-            configuration.setdefault("delayed_message_exchange", None)
             PikaTransport.defaults[target] = configuration[cfgoption]
 
 

--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -39,6 +39,7 @@ class Pika:
         username = fields.Str(required=True)
         password = fields.Str(required=True)
         vhost = fields.Str(required=True)
+        delayed_message_exchange = fields.Str(required=False)
 
     @staticmethod
     def activate(configuration):
@@ -48,7 +49,9 @@ class Pika:
             ("username", "--rabbit-user"),
             ("password", "--rabbit-pass"),
             ("vhost", "--rabbit-vhost"),
+            ("delayed_message_exchange", "--rabbit-delayed-message-exchange"),
         ]:
+            configuration.setdefault("delayed_message_exchange", None)
             PikaTransport.defaults[target] = configuration[cfgoption]
 
 

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -271,9 +271,8 @@ def test_send_message(mockpika, mock_pikathread):
     assert mockproperties.call_args[1].get("headers") == {}
     assert int(mockproperties.call_args[1].get("delivery_mode")) == 2
 
-    # Was a test for delayed sending, this is advanced in rabbitMQ and
-    # to be implemented later
-    with pytest.raises(AssertionError):
+    # No delayed message exchange specified, so raise ValueError
+    with pytest.raises(ValueError):
         transport._send(
             str(mock.sentinel.queue),
             mock.sentinel.message,

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -271,14 +271,17 @@ def test_send_message(mockpika, mock_pikathread):
     assert mockproperties.call_args[1].get("headers") == {}
     assert int(mockproperties.call_args[1].get("delivery_mode")) == 2
 
-    # No delayed message exchange specified, so raise ValueError
-    with pytest.raises(ValueError):
-        transport._send(
-            str(mock.sentinel.queue),
-            mock.sentinel.message,
-            headers={"hdr": mock.sentinel.header},
-            delay=123,
-        )
+    transport._send(
+        str(mock.sentinel.queue),
+        mock.sentinel.message,
+        headers={"hdr": mock.sentinel.header},
+        delay=123,
+    )
+    assert mockproperties.call_args[1].get("headers") == {
+        "hdr": mock.sentinel.header,
+        "x-delay": 123000,
+    }
+    assert int(mockproperties.call_args[1].get("delivery_mode")) == 2
 
     # assert mockchannel.basic_publish.call_count == 2
     # args, kwargs = mockchannel.basic_publish.call_args


### PR DESCRIPTION
Delayed message exchanges specified with delayed_message_exchange
field in the rabbitmq configuration.

If no delayed message exchange is set, and a message is sent with
a delay, then raise a ValueError.
Otherwise send to the delayed message exchange if a delay is requested,
or to the default exchange if not.