### PR TITLE
Implementation of transport middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,4 @@ repos:
   - id: mypy
     files: 'src/.*\.py$'
     additional_dependencies: ['types-setuptools==57.0.2']
+    args: [--no-strict-optional, --ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,4 +49,3 @@ repos:
   - id: mypy
     files: 'src/.*\.py$'
     additional_dependencies: ['types-setuptools==57.0.2']
-    args: [--no-strict-optional, --ignore-missing-imports]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 bidict==0.21.4
+prometheus-client==0.13.1
 pytest==7.0.1
 pytest-cov==3.0.0
 pytest-timeout==2.1.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ bidict==0.22.0
 prometheus-client==0.13.1
 pytest==7.1.1
 pytest-cov==3.0.0
+pytest-mock==3.7.0
 pytest-timeout==2.1.0
 setuptools==61.3.1
 stomp.py==8.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,9 @@ package_dir =
 python_requires = >=3.7
 zip_safe = False
 
+[options.extras_require]
+prometheus = prometheus-client
+
 [options.entry_points]
 console_scripts =
     workflows.validate_recipe = workflows.recipe.validate:main

--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -51,6 +51,7 @@ class ServiceStarter:
         cmdline_args=None,
         program_name="start_service",
         version=workflows.version(),
+        add_metrics_option: bool = False,
         **kwargs
     ):
         """Example command line interface to start services.
@@ -76,6 +77,25 @@ class ServiceStarter:
             help="Name of the service to start. Known services: "
             + ", ".join(known_services),
         )
+        if add_metrics_option:
+            parser.add_option(
+                "-m",
+                "--metrics",
+                dest="metrics",
+                action="store_true",
+                default=False,
+                help=(
+                    "Record metrics for this service and expose them on the port defined by"
+                    "the --metrics-port option."
+                ),
+            )
+            parser.add_option(
+                "--metrics-port",
+                dest="metrics_port",
+                default=8080,
+                type="int",
+                help="Expose metrics via a prometheus endpoint on this port.",
+            )
         workflows.transport.add_command_line_options(parser, transport_argument=True)
 
         # Call on_parser_preparation hook
@@ -117,7 +137,15 @@ class ServiceStarter:
             if matching and len(matching) == 1:
                 options.service = matching[0]
 
-        kwargs.update({"service": options.service, "transport": transport_factory})
+        kwargs.update(
+            {
+                "service": options.service,
+                "transport": transport_factory,
+            },
+        )
+        kwargs.setdefault("environment", {})
+        if add_metrics_option:
+            kwargs["environment"]["metrics"] = {"port": options.metrics_port}
 
         # Call before_frontend_construction hook
         kwargs = self.before_frontend_construction(kwargs) or kwargs

--- a/src/workflows/recipe/__init__.py
+++ b/src/workflows/recipe/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+
 from workflows.recipe.recipe import Recipe
 from workflows.recipe.validate import validate_recipe
 from workflows.recipe.wrapper import RecipeWrapper
@@ -42,6 +44,7 @@ def _wrap_subscription(
     allow_non_recipe_messages = kwargs.pop("allow_non_recipe_messages", False)
     log_extender = kwargs.pop("log_extender", None)
 
+    @functools.wraps(callback)
     def unwrap_recipe(header, message):
         """This is a helper function unpacking incoming messages when they are
         in a recipe format. Other messages are passed through unmodified.

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -194,7 +194,8 @@ class CommonService:
                 )
 
                 self.log.debug("Instrumenting transport")
-                instrument = PrometheusMiddleware(source=self.__class__.__name__)
+                source = f"{self.__module__}:{self.__class__.__name__}"
+                instrument = PrometheusMiddleware(source=source)
                 self._transport.add_middleware(instrument)
                 port = metrics["port"]
                 self.log.debug(f"Starting metrics endpoint on port {port}")

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -185,7 +185,8 @@ class CommonService:
             self.transport.subscription_callback_set_intercept(
                 self._transport_interceptor
             )
-            if metrics := self._environment.get("metrics"):
+            metrics = self._environment.get("metrics")
+            if metrics:
                 import prometheus_client
 
                 from workflows.transport.middleware.prometheus import (

--- a/src/workflows/services/common_service.py
+++ b/src/workflows/services/common_service.py
@@ -185,6 +185,20 @@ class CommonService:
             self.transport.subscription_callback_set_intercept(
                 self._transport_interceptor
             )
+            if metrics := self._environment.get("metrics"):
+                import prometheus_client
+
+                from workflows.transport.middleware.prometheus import (
+                    PrometheusMiddleware,
+                )
+
+                self.log.debug("Instrumenting transport")
+                instrument = PrometheusMiddleware(source=self.__class__.__name__)
+                self._transport.add_middleware(instrument)
+                port = metrics["port"]
+                self.log.debug(f"Starting metrics endpoint on port {port}")
+                prometheus_client.start_http_server(port=port)
+
         else:
             self.log.debug("No transport layer defined for service. Skipping.")
 

--- a/src/workflows/transport/middleware/__init__.py
+++ b/src/workflows/transport/middleware/__init__.py
@@ -62,6 +62,7 @@ class CounterMiddleware(BaseTransportMiddleware):
     def __init__(self):
         self.subscribe_count = 0
         self.send_count = 0
+        self.broadcast_count = 0
         self.ack_count = 0
         self.nack_count = 0
         self.transaction_begin_count = 0
@@ -78,6 +79,11 @@ class CounterMiddleware(BaseTransportMiddleware):
         call_next(destination, message, **kwargs)
         self.send_count += 1
         logger.info(f"send() count: {self.send_count}")
+
+    def broadcast(self, call_next: Callable, destination, message, **kwargs):
+        call_next(destination, message, **kwargs)
+        self.broadcast_count += 1
+        logger.info(f"broadcast() count: {self.broadcast_count}")
 
     def ack(
         self,

--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -90,19 +90,17 @@ class PrometheusMiddleware(BaseTransportMiddleware):
         return callable.__qualname__
 
     def subscribe(self, call_next: Callable, channel, callback, **kwargs) -> int:
-        source = self.get_callback_source(callback)
-
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
-                end_time - start_time
-            )
+            CALLBACK_PROCESSING_TIME.labels(
+                source=self.get_callback_source(callback)
+            ).observe(end_time - start_time)
             return result
 
-        SUBSCRIPTIONS.labels(source=source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
+        SUBSCRIPTIONS.labels(source=self.source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
         return call_next(channel, wrapped_callback, **kwargs)
 
     def subscribe_temporary(
@@ -112,37 +110,33 @@ class PrometheusMiddleware(BaseTransportMiddleware):
         callback: MessageCallback,
         **kwargs,
     ) -> TemporarySubscription:
-        source = self.get_callback_source(callback)
-
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
-                end_time - start_time
-            )
+            CALLBACK_PROCESSING_TIME.labels(
+                source=self.get_callback_source(callback)
+            ).observe(end_time - start_time)
             return result
 
-        TEMPORARY_SUBSCRIPTIONS.labels(source=source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
+        TEMPORARY_SUBSCRIPTIONS.labels(source=self.source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
         return call_next(channel_hint, wrapped_callback, **kwargs)
 
     def subscribe_broadcast(
         self, call_next: Callable, channel, callback, **kwargs
     ) -> int:
-        source = self.get_callback_source(callback)
-
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
-                end_time - start_time
-            )
+            CALLBACK_PROCESSING_TIME.labels(
+                source=self.get_callback_source(callback)
+            ).observe(end_time - start_time)
             return result
 
-        BROADCAST_SUBSCRIPTIONS.labels(source=source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
+        BROADCAST_SUBSCRIPTIONS.labels(source=self.source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
         return call_next(channel, wrapped_callback, **kwargs)
 
     def unsubscribe(

--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from . import BaseTransportMiddleware
+
+SUBSCRIPTIONS = Counter(
+    "workflows_transport_subscriptions_total",
+    "The total number of transport subscriptions",
+    ["source"],
+)
+CALLBACK_PROCESSING_TIME = Histogram(
+    "workflows_callback_processing_time_seconds",
+    "Histogram of callback processing time (in seconds)",
+    ["source"],
+)
+ACKS = Counter(
+    "workflows_transport_ack_total",
+    "Total count of transport acknowledgements.",
+    ["source"],
+)
+NACKS = Counter(
+    "workflows_transport_nack_total",
+    "Total count of transport negative acknowledgements.",
+    ["source"],
+)
+SENDS = Counter(
+    "workflows_transport_send_total",
+    "Total number of messages sent",
+    ["source"],
+)
+BROADCASTS = Counter(
+    "workflows_transport_broadcast_total",
+    "Total number of messages broadcast",
+    ["source"],
+)
+TRANSACTION_BEGIN = Counter(
+    "workflows_transport_transaction_begin_total",
+    "Total number of transactions begun",
+    ["source"],
+)
+TRANSACTION_ABORT = Counter(
+    "workflows_transport_transaction_abort_total",
+    "Total number of transactions aborted",
+    ["source"],
+)
+TRANSACTION_COMMIT = Counter(
+    "workflows_transport_transaction_commit_total",
+    "Total number of transactions committed",
+    ["source"],
+)
+TRANSACTIONS_IN_PROGRESS = Gauge(
+    "workflows_transport_transactions_in_progress",
+    "Total number of transactions currently in progress",
+    ["source"],
+)
+
+
+class PrometheusMiddleware(BaseTransportMiddleware):
+    def __init__(self, source: str):
+        self.source = source
+
+    def subscribe(self, call_next: Callable, channel, callback, **kwargs) -> int:
+        def wrapped_callback(header, message):
+            start_time = time.perf_counter()
+            result = callback(header, message)
+            end_time = time.perf_counter()
+            CALLBACK_PROCESSING_TIME.labels(source=self.source).observe(
+                end_time - start_time
+            )
+            return result
+
+        SUBSCRIPTIONS.labels(source=self.source).inc()
+        return call_next(channel, wrapped_callback, **kwargs)
+
+    def send(self, call_next: Callable, destination, message, **kwargs):
+        SENDS.labels(source=self.source).inc()
+        call_next(destination, message, **kwargs)
+
+    def ack(
+        self,
+        call_next: Callable,
+        message,
+        subscription_id: Optional[int] = None,
+        **kwargs
+    ):
+        ACKS.labels(source=self.source).inc()
+        call_next(message, subscription_id=subscription_id, **kwargs)
+
+    def nack(
+        self,
+        call_next: Callable,
+        message,
+        subscription_id: Optional[int] = None,
+        **kwargs
+    ):
+        NACKS.labels(source=self.source).inc()
+        call_next(message, subscription_id=subscription_id, **kwargs)
+
+    def transaction_begin(self, call_next: Callable, *args, **kwargs) -> int:
+        TRANSACTION_BEGIN.labels(source=self.source).inc()
+        TRANSACTIONS_IN_PROGRESS.labels(source=self.source).inc()
+        return call_next(*args, **kwargs)
+
+    def transaction_abort(self, call_next: Callable, *args, **kwargs):
+        TRANSACTION_ABORT.labels(source=self.source).inc()
+        TRANSACTIONS_IN_PROGRESS.labels(source=self.source).dec()
+        call_next(*args, **kwargs)
+
+    def transaction_commit(self, call_next: Callable, *args, **kwargs):
+        TRANSACTION_COMMIT.labels(source=self.source).inc()
+        TRANSACTIONS_IN_PROGRESS.labels(source=self.source).dec()
+        call_next(*args, **kwargs)

--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -33,6 +33,7 @@ CALLBACK_PROCESSING_TIME = Histogram(
     "workflows_callback_processing_time_seconds",
     "Histogram of callback processing time (in seconds)",
     ["source"],
+    unit="seconds",
 )
 ACKS = Counter(
     "workflows_transport_ack_total",

--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import time
 from typing import Callable, Optional
 
@@ -81,18 +82,27 @@ class PrometheusMiddleware(BaseTransportMiddleware):
     def __init__(self, source: str):
         self.source = source
 
+    @staticmethod
+    def get_callback_source(callable: Callable):
+        module = inspect.getmodule(callable)
+        if module:
+            return f"{module.__name__}:{callable.__qualname__}"
+        return callable.__qualname__
+
     def subscribe(self, call_next: Callable, channel, callback, **kwargs) -> int:
+        source = self.get_callback_source(callback)
+
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=self.source).observe(
+            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
                 end_time - start_time
             )
             return result
 
-        SUBSCRIPTIONS.labels(source=self.source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
+        SUBSCRIPTIONS.labels(source=source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
         return call_next(channel, wrapped_callback, **kwargs)
 
     def subscribe_temporary(
@@ -102,34 +112,37 @@ class PrometheusMiddleware(BaseTransportMiddleware):
         callback: MessageCallback,
         **kwargs,
     ) -> TemporarySubscription:
+        source = self.get_callback_source(callback)
+
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=self.source).observe(
+            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
                 end_time - start_time
             )
             return result
 
-        TEMPORARY_SUBSCRIPTIONS.labels(source=self.source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
+        TEMPORARY_SUBSCRIPTIONS.labels(source=source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
         return call_next(channel_hint, wrapped_callback, **kwargs)
 
     def subscribe_broadcast(
         self, call_next: Callable, channel, callback, **kwargs
     ) -> int:
+        source = self.get_callback_source(callback)
+
         def wrapped_callback(header, message):
             start_time = time.perf_counter()
             result = callback(header, message)
             end_time = time.perf_counter()
-            CALLBACK_PROCESSING_TIME.labels(source=self.source).observe(
+            CALLBACK_PROCESSING_TIME.labels(source=source).observe(
                 end_time - start_time
             )
-            print(f"{end_time - start_time: .3f}")
             return result
 
-        BROADCAST_SUBSCRIPTIONS.labels(source=self.source).inc()
-        ACTIVE_SUBSCRIPTIONS.labels(source=self.source).inc()
+        BROADCAST_SUBSCRIPTIONS.labels(source=source).inc()
+        ACTIVE_SUBSCRIPTIONS.labels(source=source).inc()
         return call_next(channel, wrapped_callback, **kwargs)
 
     def unsubscribe(

--- a/src/workflows/transport/offline_transport.py
+++ b/src/workflows/transport/offline_transport.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 import logging
 import pprint
-from typing import Any, Dict
+from typing import Any, Dict, Type
 
+from workflows.transport import middleware
 from workflows.transport.common_transport import CommonTransport, json_serializer
 
 _offlog = logging.getLogger("workflows.transport.offline_transport")
@@ -20,8 +21,11 @@ class OfflineTransport(CommonTransport):
     # Effective configuration
     config: Dict[Any, Any] = {}
 
-    def __init__(self):
+    def __init__(
+        self, middleware: list[Type[middleware.BaseTransportMiddleware]] = None
+    ):
         self._connected = False
+        super().__init__(middleware=middleware)
 
     def connect(self):
         self._connected = True

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -68,7 +68,7 @@ class PikaTransport(CommonTransport):
         self._conn = None
         self._connected = False
         self._lock = threading.RLock()
-        self._pika_thread: _PikaThread | None = None
+        self._pika_thread: _PikaThread
         self._vhost = "/"
         super().__init__(middleware=middleware)
 
@@ -287,7 +287,7 @@ class PikaTransport(CommonTransport):
     def connect(self) -> bool:
         """Ensure both connection and channel to the RabbitMQ server are open."""
         with self._lock:
-            if self._pika_thread is None:
+            if not hasattr(self, "_pika_thread"):
                 self._pika_thread = _PikaThread(self._generate_connection_parameters())
         try:
             self._pika_thread.start()
@@ -302,7 +302,7 @@ class PikaTransport(CommonTransport):
         """Return connection status."""
         # TODO: Does this question even make sense with reconnection?
         #       Surely .connection_alive is (slightly) better?
-        return self._pika_thread is not None and self._pika_thread.connection_alive
+        return hasattr(self, "_pika_thread") and self._pika_thread.connection_alive
 
     def disconnect(self):
         """Gracefully close connection to pika server"""

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -12,13 +12,14 @@ import time
 import uuid
 from concurrent.futures import Future
 from enum import Enum, auto
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import pika.exceptions
 from bidict import bidict
 from pika.adapters.blocking_connection import BlockingChannel
 
 import workflows.util
+from workflows.transport import middleware
 from workflows.transport.common_transport import (
     CommonTransport,
     MessageCallback,
@@ -60,13 +61,16 @@ class PikaTransport(CommonTransport):
     # Effective configuration
     config: Dict[Any, Any] = {}
 
-    def __init__(self):
+    def __init__(
+        self, middleware: list[Type[middleware.BaseTransportMiddleware]] = None
+    ):
         self._channel = None
         self._conn = None
         self._connected = False
         self._lock = threading.RLock()
-        self._pika_thread = None
+        self._pika_thread: _PikaThread | None = None
         self._vhost = "/"
+        super().__init__(middleware=middleware)
 
     def get_namespace(self) -> str:
         """Return the RabbitMQ virtual host"""
@@ -283,7 +287,7 @@ class PikaTransport(CommonTransport):
     def connect(self) -> bool:
         """Ensure both connection and channel to the RabbitMQ server are open."""
         with self._lock:
-            if not self._pika_thread:
+            if self._pika_thread is None:
                 self._pika_thread = _PikaThread(self._generate_connection_parameters())
         try:
             self._pika_thread.start()
@@ -298,7 +302,7 @@ class PikaTransport(CommonTransport):
         """Return connection status."""
         # TODO: Does this question even make sense with reconnection?
         #       Surely .connection_alive is (slightly) better?
-        return self._pika_thread and self._pika_thread.connection_alive
+        return self._pika_thread is not None and self._pika_thread.connection_alive
 
     def disconnect(self):
         """Gracefully close connection to pika server"""

--- a/src/workflows/transport/stomp_transport.py
+++ b/src/workflows/transport/stomp_transport.py
@@ -5,11 +5,12 @@ import json
 import threading
 import time
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
 import stomp
 
 import workflows.util
+from workflows.transport import middleware
 from workflows.transport.common_transport import (
     CommonTransport,
     MessageCallback,
@@ -32,7 +33,9 @@ class StompTransport(CommonTransport):
     # Effective configuration
     config: Dict[Any, Any] = {}
 
-    def __init__(self):
+    def __init__(
+        self, middleware: list[Type[middleware.BaseTransportMiddleware]] = None
+    ):
         self._connected = False
         self._namespace = ""
         self._idcounter = 0
@@ -41,6 +44,7 @@ class StompTransport(CommonTransport):
         #   self._stomp_listener = stomp.PrintingListener()
         self._stomp_listener.on_message = self._on_message
         self._stomp_listener.on_before_message = lambda frame: frame
+        super().__init__()
 
     def get_namespace(self):
         """Return the stomp namespace. This is a prefix used for all topic and

--- a/tests/contrib/test_start_service.py
+++ b/tests/contrib/test_start_service.py
@@ -39,6 +39,8 @@ def test_script_initialises_transport_and_starts_frontend(
     mock_tlookup.assert_called_once_with(mock.sentinel.transport)
     mock_parser.assert_called_once_with(usage=mock.ANY, version=mock.sentinel.version)
     mock_frontend.Frontend.assert_called_once_with(
-        service="SomeService", transport=mock_tlookup.return_value
+        service="SomeService",
+        transport=mock_tlookup.return_value,
+        environment={},
     )
     mock_frontend.Frontend.return_value.run.assert_called_once_with()

--- a/tests/services/test_sample_producer.py
+++ b/tests/services/test_sample_producer.py
@@ -63,4 +63,7 @@ def test_service_with_metrics(mocker):
     p.create_message()
 
     data = prometheus_client.generate_latest().decode("ascii")
-    assert 'workflows_transport_send_total{source="SampleProducer"} 2.0' in data
+    assert (
+        'workflows_transport_send_total{source="workflows.services.sample_producer:SampleProducer"} 2.0'
+        in data
+    )

--- a/tests/transport/test_middleware.py
+++ b/tests/transport/test_middleware.py
@@ -108,7 +108,6 @@ def test_prometheus_middleware():
     txid = offline.transaction_begin()
 
     data = prometheus_client.generate_latest().decode("ascii")
-    print(data)
     expected_output = """
 workflows_callback_processing_time_seconds_bucket{le="+Inf",source="foo"} 3.0
 workflows_callback_processing_time_seconds_count{source="foo"} 3.0

--- a/tests/transport/test_middleware.py
+++ b/tests/transport/test_middleware.py
@@ -109,9 +109,9 @@ def test_prometheus_middleware():
 
     data = prometheus_client.generate_latest().decode("ascii")
     expected_output = """
-workflows_callback_processing_time_seconds_bucket{le="+Inf",source="foo"} 3.0
-workflows_callback_processing_time_seconds_count{source="foo"} 3.0
-workflows_callback_processing_time_seconds_sum{source="foo"}
+workflows_callback_processing_time_seconds_bucket{le="+Inf",source="test_middleware:test_prometheus_middleware.<locals>.callback"} 3.0
+workflows_callback_processing_time_seconds_count{source="test_middleware:test_prometheus_middleware.<locals>.callback"} 3.0
+workflows_callback_processing_time_seconds_sum{source="test_middleware:test_prometheus_middleware.<locals>.callback"}
 workflows_transport_active_subscriptions{source="foo"} 2.0
 workflows_transport_subscriptions_total{source="foo"} 1.0
 workflows_transport_temporary_subscriptions_total{source="foo"} 1.0

--- a/tests/transport/test_middleware.py
+++ b/tests/transport/test_middleware.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import time
+from unittest import mock
+
+import pytest
+
+from workflows.transport import middleware
+from workflows.transport.offline_transport import OfflineTransport
+
+
+def test_counter_middleware():
+    offline = OfflineTransport()
+    offline.connect()
+    counter = middleware.CounterMiddleware()
+    offline.add_middleware(counter)
+
+    for i in range(10):
+        offline.send(str(mock.sentinel.channel), str(mock.sentinel.message))
+        assert counter.send_count == i + 1
+
+    offline.ack(str(mock.sentinel.messagid), 1)
+    assert counter.ack_count == 1
+
+    offline.nack(str(mock.sentinel.messagid), 1)
+    assert counter.nack_count == 1
+
+    offline.broadcast(str(mock.sentinel.channel), str(mock.sentinel.message))
+    assert counter.broadcast_count == 1
+
+    mock_callback = mock.Mock()
+    offline.subscribe(str(mock.sentinel.channel), mock_callback)
+    assert counter.subscribe_count == 1
+
+    txid = offline.transaction_begin()
+    offline.transaction_abort(txid)
+    assert counter.transaction_begin_count == 1
+    assert counter.transaction_abort_count == 1
+
+    txid = offline.transaction_begin()
+    offline.transaction_commit(txid)
+    assert counter.transaction_begin_count == 2
+    assert counter.transaction_commit_count == 1
+
+
+def test_timer_middleware(caplog):
+    offline = OfflineTransport()
+    offline.connect()
+    timer = middleware.TimerMiddleware()
+    offline.add_middleware(timer)
+
+    def callback(header, message):
+        time.sleep(1)
+
+    subscription_id = offline.subscribe(str(mock.sentinel.channel), callback)
+    with caplog.at_level(logging.INFO):
+        offline.subscription_callback(subscription_id)(
+            {"destination": "foo"}, str(mock.sentinel.message)
+        )
+        assert "Callback for foo took:" in caplog.text
+
+
+def test_prometheus_middleware():
+    prometheus_client = pytest.importorskip("prometheus_client")
+
+    from workflows.transport.middleware import prometheus
+
+    offline = OfflineTransport()
+    offline.connect()
+    instrument = prometheus.PrometheusMiddleware(source="foo")
+    offline.add_middleware(instrument)
+
+    for i in range(10):
+        offline.send(str(mock.sentinel.channel), str(mock.sentinel.message))
+
+    offline.ack(str(mock.sentinel.messagid), 1)
+    offline.nack(str(mock.sentinel.messagid), 1)
+    offline.broadcast(str(mock.sentinel.channel), str(mock.sentinel.message))
+
+    def callback(header, message):
+        time.sleep(1)
+
+    subscription_id = offline.subscribe(str(mock.sentinel.channel), callback)
+    offline.subscription_callback(subscription_id)(
+        {"destination": "foo"}, str(mock.sentinel.message)
+    )
+
+    txid = offline.transaction_begin()
+    offline.transaction_abort(txid)
+
+    txid = offline.transaction_begin()
+    offline.transaction_commit(txid)
+
+    txid = offline.transaction_begin()
+
+    data = prometheus_client.generate_latest().decode("ascii")
+    expected_output = """
+workflows_callback_processing_time_seconds_bucket{le="+Inf",source="foo"} 1.0
+workflows_callback_processing_time_seconds_count{source="foo"} 1.0
+workflows_transport_subscriptions_total{source="foo"} 1.0
+workflows_transport_ack_total{source="foo"} 1.0
+workflows_transport_nack_total{source="foo"} 1.0
+workflows_transport_send_total{source="foo"} 10.0
+workflows_transport_transaction_begin_total{source="foo"} 3.0
+workflows_transport_transaction_abort_total{source="foo"} 1.0
+workflows_transport_transaction_commit_total{source="foo"} 1.0
+workflows_transport_transactions_in_progress{source="foo"} 1.0
+"""
+    for line in expected_output:
+        assert line in data

--- a/tests/transport/test_offline.py
+++ b/tests/transport/test_offline.py
@@ -345,6 +345,42 @@ def test_subscribe_to_broadcast(caplog):
         ]
 
 
+def test_subscribe_temporary(caplog):
+    """Test subscribing to a temporary queue and callback functions."""
+    mock_cb1 = mock.Mock()
+    channel_hint = "foo"
+    offline = OfflineTransport()
+    offline.connect()
+
+    with caplog.at_level(logging.INFO):
+        channel = offline._subscribe_temporary(
+            1,
+            channel_hint,
+            mock_cb1,
+            transformation=mock.sentinel.transformation,
+        )
+        message = f"Subscribing to messages on {channel}"
+        assert caplog.record_tuples == [
+            (
+                "workflows.transport.offline_transport",
+                logging.INFO,
+                f"Offline Transport: {message}",
+            )
+        ]
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        offline._unsubscribe(1)
+        message = "Ending subscription #1"
+        assert caplog.record_tuples == [
+            (
+                "workflows.transport.offline_transport",
+                logging.INFO,
+                f"Offline Transport: {message}",
+            )
+        ]
+
+
 def test_transaction_calls(caplog):
     """Test that calls to create, commit, abort transactions are properly logged."""
     offline = OfflineTransport()


### PR DESCRIPTION
This enables user code to add middleware that can intercept or monitor transport calls. Basic counter and timer middleware
are provided as examples.

Add `PrometheusMiddleware` that can be used to instrument downstream code to collect prometheus metrics for exposing via a prometheus endpoint.

A minimal example to add prometheus instrumentation is:
```
import prometheus_client
from workflows.transport.offline_transport import OfflineTransport
from workflows.transport.middleware.prometheus import PrometheusMiddleware

transport = OfflineTransport()
instrument = PrometheusMiddleware(source="my-service")
transport.add_middleware(instrument)
prometheus_client.start_http_server(8000)
transport.send(...)
```

Add --no-strict-optional and --ignore-missing-imports to mypy pre-commit-config to silence complaints from mypy not being able to determine that self._pika_thread is not None in PikaTransport.

Taking heavy inspiration from [Starlette middleware](https://www.starlette.io/middleware/) and related prometheus middleware extensions, [`starlette-prometheus`](https://github.com/perdy/starlette-prometheus) and [`prometheus-fastapi-instrumentator`](https://github.com/trallnag/prometheus-fastapi-instrumentator).