### PR TITLE
Bind temporary queues to delayed exchange

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -15,6 +15,15 @@ steps:
     cat <<EOF >Dockerfile
     FROM rabbitmq:3.9-management
     COPY rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
+
+    RUN apt-get update && \
+      apt-get install -y curl unzip
+    RUN mkdir -p /plugins && \
+      curl -fsSL \
+      -o "/plugins/rabbitmq_delayed_message_exchange-3.9.0.ez" \
+      https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.9.0/rabbitmq_delayed_message_exchange-3.9.0.ez
+
+    RUN rabbitmq-plugins enable --offline rabbitmq_delayed_message_exchange
     EOF
 
     docker build -t azure-rabbitmq .

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -989,13 +989,11 @@ class _PikaThread(threading.Thread):
                     assert (
                         subscription_id not in self._subscriptions
                     ), f"Subscription request {subscription_id} rejected due to existing subscription {self._subscriptions[subscription_id]}"
-                    temporary_queue_name = (
-                        self._get_shared_channel()
-                        .queue_declare(
-                            queue, auto_delete=True, exclusive=True, durable=False
-                        )
-                        .method.queue
-                    )
+                    channel = self._get_shared_channel()
+                    temporary_queue_name = channel.queue_declare(
+                        queue, auto_delete=True, exclusive=True, durable=False
+                    ).method.queue
+                    channel.queue_bind(exchange="delayed", queue=temporary_queue_name)
                     temporary_subscription = _PikaSubscription(
                         arguments={},
                         auto_ack=auto_ack,

--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -993,7 +993,7 @@ class _PikaThread(threading.Thread):
                     temporary_queue_name = channel.queue_declare(
                         queue, auto_delete=True, exclusive=True, durable=False
                     ).method.queue
-                    channel.queue_bind(exchange="delayed", queue=temporary_queue_name)
+                    channel.queue_bind(queue=temporary_queue_name, exchange="delayed")
                     temporary_subscription = _PikaSubscription(
                         arguments={},
                         auto_ack=auto_ack,

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -55,6 +55,11 @@ def pikatransport(revert_classvariables, connection_params):
     # every individual test.
     pt = PikaTransport()
     pt.connect()
+    pt._pika_thread._get_shared_channel().exchange_declare(
+        "delayed",
+        exchange_type="x-delayed-message",
+        arguments={"x-delayed-type": "direct"},
+    )
     yield pt
     pt.disconnect()
 

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -1306,9 +1306,9 @@ def test_full_stack_temporary_queue_roundtrip(pikatransport):
 
     outstanding_messages = set()
     for n in range(6):
+        delay = 1 if n == 1 else None
         outstanding_messages.add((n, f"message {n}"))
-        pikatransport.send(ts[n].queue_name, f"message {n}")
-
+        pikatransport.send(ts[n].queue_name, f"message {n}", delay=delay)
     try:
         while outstanding_messages:
             s, _, m = replies.get(timeout=1.5)


### PR DESCRIPTION
This is required for some of the dlstbx system tests

* Azure: enable rabbitmq_delayed_message_exchange plugin
* Declare a delayed exchange in PikaTransport tests
* Test sending to temporary queue with delay