### PR TITLE
Support (de)serializing yaml-format recipes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,4 @@ repos:
   hooks:
   - id: mypy
     files: 'src/.*\.py$'
-    additional_dependencies: ['types-setuptools==57.0.2']
+    additional_dependencies: ['types-setuptools==57.0.2', 'types-PyYAML']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,4 +48,4 @@ repos:
   hooks:
   - id: mypy
     files: 'src/.*\.py$'
-    additional_dependencies: ['types-setuptools==57.0.2', 'types-PyYAML']
+    additional_dependencies: ['types-setuptools==57.0.2']

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ bidict==0.21.4
 pytest==7.1.1
 pytest-cov==3.0.0
 pytest-timeout==2.1.0
+pyyamml
 setuptools==60.10.0
 stomp.py==8.0.0
 pika==1.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@ bidict==0.21.4
 pytest==7.1.1
 pytest-cov==3.0.0
 pytest-timeout==2.1.0
-pyyamml
+ruamel.yaml
 setuptools==60.10.0
 stomp.py==8.0.0
 pika==1.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 install_requires =
     bidict
     pika
-    pyyaml
+    ruamel.yaml
     setuptools
     stomp.py>=7
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ project_urls =
 install_requires =
     bidict
     pika
+    pyyaml
     setuptools
     stomp.py>=7
 packages = find:

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -52,9 +52,17 @@ class Recipe:
             recipe["start"] = [tuple(x) for x in recipe["start"]]
         return recipe
 
-    def serialize(self):
-        """Write out the current recipe as serialized json string."""
-        return json.dumps(self.recipe)
+    def serialize(self, format: str = "json"):
+        """Write out the current recipe as serialized string.
+
+        Supported serialization formats are "json" and "yaml".
+        """
+        if format == "json":
+            return json.dumps(self.recipe)
+        elif format == "yaml":
+            return yaml.safe_dump(self.recipe)
+        else:
+            raise ValueError(f"Unsupported serialization format {format}")
 
     def pretty(self):
         """Write out the current recipe as serialized json string with pretty formatting."""

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -5,6 +5,8 @@ import json
 import string
 from typing import Any, Dict
 
+import yaml
+
 import workflows
 
 basestring = (str, bytes)
@@ -29,7 +31,7 @@ class Recipe:
     def deserialize(self, string):
         """Convert a recipe that has been stored as serialized json string to a
         data structure."""
-        return self._sanitize(json.loads(string))
+        return self._sanitize(yaml.safe_load(string))
 
     @staticmethod
     def _sanitize(recipe):

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -7,10 +7,25 @@ import string
 from typing import Any, Dict
 
 from ruamel.yaml import YAML
+from ruamel.yaml.constructor import SafeConstructor
 
 import workflows
 
 basestring = (str, bytes)
+
+
+def construct_yaml_map(self, node):
+    # Test if there are duplicate node keys
+    # In the case of duplicate keys, last wins
+    data = {}
+    yield data
+    for key_node, value_node in node.value:
+        key = self.construct_object(key_node, deep=True)
+        val = self.construct_object(value_node, deep=True)
+        data[key] = val
+
+
+SafeConstructor.add_constructor("tag:yaml.org,2002:map", construct_yaml_map)
 
 
 class Recipe:

--- a/src/workflows/recipe/recipe.py
+++ b/src/workflows/recipe/recipe.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import copy
+import io
 import json
 import string
 from typing import Any, Dict
 
-import yaml
+from ruamel.yaml import YAML
 
 import workflows
 
@@ -31,7 +32,9 @@ class Recipe:
     def deserialize(self, string):
         """Convert a recipe that has been stored as serialized json string to a
         data structure."""
-        return self._sanitize(yaml.safe_load(string))
+        with YAML(typ="safe") as yaml:
+            yaml.allow_duplicate_keys = True
+            return self._sanitize(yaml.load(string))
 
     @staticmethod
     def _sanitize(recipe):
@@ -60,7 +63,10 @@ class Recipe:
         if format == "json":
             return json.dumps(self.recipe)
         elif format == "yaml":
-            return yaml.safe_dump(self.recipe)
+            buf = io.StringIO()
+            with YAML(output=buf, typ="safe") as yaml:
+                yaml.dump(self.recipe)
+            return buf.getvalue()
         else:
             raise ValueError(f"Unsupported serialization format {format}")
 

--- a/tests/recipe/test_recipe.py
+++ b/tests/recipe/test_recipe.py
@@ -471,3 +471,21 @@ def test_unsupported_serialization_format_raises_error():
 
     with pytest.raises(ValueError):
         A.serialize(format="xml")
+
+
+def test_json_recipe_with_pseudo_comment():
+    recipe = """
+        {
+          "1": ["This is a comment"],
+          "1": {
+            "parameters": {
+              "foo": "bar"
+            }
+          },
+          "start": [
+            [1, []]
+          ]
+        }
+    """
+    A = workflows.recipe.Recipe(recipe)
+    assert A.recipe == {"start": [(1, [])], 1: {"parameters": {"foo": "bar"}}}

--- a/tests/recipe/test_recipe.py
+++ b/tests/recipe/test_recipe.py
@@ -4,7 +4,7 @@ import json
 from unittest import mock
 
 import pytest
-import yaml
+from ruamel.yaml import YAML
 
 import workflows
 import workflows.recipe
@@ -456,14 +456,15 @@ def test_serialize_yaml():
     with pytest.raises(json.JSONDecodeError):
         json.loads(A.serialize(format="yaml"))
 
-    assert (
-        A.recipe
-        == workflows.recipe.Recipe(yaml.safe_load(A.serialize(format="yaml"))).recipe
-    )
-    assert (
-        B.recipe
-        == workflows.recipe.Recipe(yaml.safe_load(B.serialize(format="yaml"))).recipe
-    )
+    with YAML(typ="safe") as yaml:
+        assert (
+            A.recipe
+            == workflows.recipe.Recipe(yaml.load(A.serialize(format="yaml"))).recipe
+        )
+        assert (
+            B.recipe
+            == workflows.recipe.Recipe(yaml.load(B.serialize(format="yaml"))).recipe
+        )
 
 
 def test_unsupported_serialization_format_raises_error():

--- a/tests/recipe/test_recipe.py
+++ b/tests/recipe/test_recipe.py
@@ -368,3 +368,64 @@ def test_merging_recipes():
             C.recipe.values(),
         )
     )
+
+
+def test_deserialize_json():
+    healthy_recipe = """
+        {
+          "1": {
+            "queue": "my.queue",
+            "parameters": {
+              "foo": "bar",
+              "ingredients": ["ham", "spam"],
+              "workingdir": "/path/to/workingdir",
+              "output_file": "out.txt"
+            }
+          },
+          "start": [
+            [1, []]
+          ]
+        }
+    """
+    A = workflows.recipe.Recipe(healthy_recipe)
+    assert A.recipe == {
+        "start": [(1, [])],
+        1: {
+            "queue": "my.queue",
+            "parameters": {
+                "foo": "bar",
+                "ingredients": ["ham", "spam"],
+                "workingdir": "/path/to/workingdir",
+                "output_file": "out.txt",
+            },
+        },
+    }
+
+
+def test_deserialize_yaml():
+    healthy_recipe = """
+1:
+  queue: my.queue
+  parameters:
+    foo: bar
+    ingredients:
+    - ham
+    - spam
+    workingdir: /path/to/workingdir
+    output_file: out.txt
+start:
+- [1, []]
+"""
+    A = workflows.recipe.Recipe(healthy_recipe)
+    assert A.recipe == {
+        "start": [(1, [])],
+        1: {
+            "queue": "my.queue",
+            "parameters": {
+                "foo": "bar",
+                "ingredients": ["ham", "spam"],
+                "workingdir": "/path/to/workingdir",
+                "output_file": "out.txt",
+            },
+        },
+    }

--- a/tests/recipe/test_validate.py
+++ b/tests/recipe/test_validate.py
@@ -4,11 +4,11 @@ Tests the functionality of validate.py with several different recipes which shou
 
 from __future__ import annotations
 
-import json
 import sys
 from unittest import mock
 
 import pytest
+import ruamel.yaml
 
 import workflows
 from workflows.recipe.validate import main, validate_recipe
@@ -64,8 +64,8 @@ def test_value_error_when_validating_bad_json(tmpdir):
     recipe_file = tmpdir.join("recipe.json")
     recipe_file.write(bad_json)
 
-    # Run validate with mock open, expect JSON error
-    with pytest.raises(json.JSONDecodeError):
+    # Run validate with mock open, expect parsing error
+    with pytest.raises(ruamel.yaml.parser.ParserError):
         validate_recipe(recipe_file.strpath)
 
 

--- a/tests/recipe/test_wrapped_recipe.py
+++ b/tests/recipe/test_wrapped_recipe.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-import workflows
+import workflows.transport.common_transport
 from workflows.recipe import Recipe
 from workflows.recipe.wrapper import RecipeWrapper
 


### PR DESCRIPTION
This works by parsing serialized recipes with a [YAML 1.2](https://yaml.org/spec/1.2.2/)-compatible parser, of which [JSON is a strict superset](https://yaml.org/spec/1.2.2/#12-yaml-history).

The following JSON-format recipe:
```
{
  "1": [
    "Example recipe for per-image-analysis storing results in ISPyB directly"
  ],
  "1": { "service": "DLS file watcher",
         "queue": "filewatcher",
         "parameters": { "pattern": "/path/to/images/2A4_1_%04d.cbf",
                         "pattern-start": "100",
                         "pattern-end": "100"
                       },
         "output": { "every": 2 }
       },
  "2": { "service": "DLS Per-Image-Analysis",
         "queue": "per_image_analysis",
         "output": 6
       },
  "6": { "service": "DLS ISPyB connector",
         "queue": "ispyb_pia",
         "parameters": { "ispyb_command": "store_per_image_analysis_results",
                         "program_id": "$ispyb_autoprocprogram_id",
                         "dcid": "{ispyb_dcid}"
                       }
       },
  "start": [
      [1, []]
  ]
}
```
could equivalently be represented in YAML format as:
```
1:
  output:
    every: 2
  parameters:
    pattern: /path/to/images/2A4_1_%04d.cbf
    pattern-end: 100
    pattern-start: 100
  queue: filewatcher
  service: DLS file watcher
2:
  output:
    - 6
  queue: per_image_analysis
  service: DLS Per-Image-Analysis
6:
  parameters:
    dcid: {ispyb_dcid}
    ispyb_command: store_per_image_analysis_results
    program_id: $ispyb_autoprocprogram_id
  queue: ispyb_pia
  service: DLS ISPyB connector
start:
- [1, []]
```

`workflows.recipe.Recipe.serialize()` now supports the keyword argument `format="json"`. Acceptable values are `"json"` or `"yaml"`.

No performance comparisons between the two parsers have been made yet. It could be possible to wrap the parsing in a `try/except` whereby we first try parsing with the native JSON parser, and failover to YAML in the event of failure, although this does complicate error handling.