### PR TITLE
Ensure handed out Futures eventually terminate

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -1512,9 +1512,13 @@ class _PikaThread(threading.Thread):
     def _register_future_and_callback(
         self, future: Future[Any], callback: Callable[[], None]
     ) -> None:
-        """Make note of a future and associated callback function for
-        encapsulated send() calls so that we can keep track of them even
-        following an unexpected connection loss."""
+        """
+        Queue a callback with the connection, and record its future.
+
+        Recording the future allows us to keep track of them even
+        following an unexpected connection loss, and either send them
+        upon reconnection or mark them as failed.
+        """
         assert self._connection is not None
         assert future not in self._future_tracker, "Futures must be unique"
         self._future_tracker[future] = callback


### PR DESCRIPTION
Keep track of all Futures that are handed out to calling functions and
ensure that they are either resubmitted on connection
failure/reconnection or are cancelled/raise a Disconnected exception
when the underlying connection has permanently failed.

We noticed that when a connection fails due to an unclean connection loss (in this specific case: client process is suspended, server closes connection, client resumes) that the client connection can be lost with a callback function not being run at all. In that case the future is never touched and remains open forever. This PR ensures we don't lose track of futures.

This probably still does not handle transactions correctly.