### PR TITLE
Enable custom message mangling functions

### DIFF
--- a/src/workflows/transport/common_transport.py
+++ b/src/workflows/transport/common_transport.py
@@ -68,7 +68,7 @@ class CommonTransport:
         self,
         channel,
         callback,
-        mangle_for_receiving: Callable | None = None,
+        mangle_for_receiving: Callable[[Any], Any] | None = None,
         disable_mangling: bool = False,
         **kwargs,
     ) -> int:

--- a/tests/transport/test_common.py
+++ b/tests/transport/test_common.py
@@ -280,7 +280,7 @@ def test_send_message_custom_mangling():
     ct.send(
         mock.sentinel.destination,
         message,
-        mangle_for_sending=lambda message: message | {"ham": "spam"},
+        mangle_for_sending=lambda message: {**message, "ham": "spam"},
     )
 
     ct._send.assert_called_once_with(
@@ -325,7 +325,7 @@ def test_broadcast_message_custom_mangling():
     ct.broadcast(
         mock.sentinel.destination,
         message,
-        mangle_for_sending=lambda message: message | {"ham": "spam"},
+        mangle_for_sending=lambda message: {**message, "ham": "spam"},
     )
 
     ct._broadcast.assert_called_once_with(

--- a/tests/transport/test_common.py
+++ b/tests/transport/test_common.py
@@ -213,9 +213,27 @@ def test_simple_send_message():
     ct._send.assert_called_with(mock.sentinel.destination, mock.sentinel.message)
 
 
+def test_send_message_custom_mangling():
+    """Pass messages to send(), modified message should be routed to specific _send()"""
+    ct = CommonTransport()
+    ct._send = mock.Mock()
+
+    message = {"foo": "bar"}
+
+    ct.send(
+        mock.sentinel.destination,
+        message,
+        mangle_for_sending=lambda message: message | {"ham": "spam"},
+    )
+
+    ct._send.assert_called_once_with(
+        mock.sentinel.destination,
+        {"foo": "bar", "ham": "spam"},
+    )
+
+
 def test_simple_broadcast_message():
     """Pass messages to broadcast(), should be routed to specific _broadcast()"""
-
     ct = CommonTransport()
     ct._broadcast = mock.Mock()
 
@@ -238,6 +256,25 @@ def test_simple_broadcast_message():
     ct.broadcast(mock.sentinel.destination, mock.sentinel.message)
 
     ct._broadcast.assert_called_with(mock.sentinel.destination, mock.sentinel.message)
+
+
+def test_broadcast_message_custom_mangling():
+    """Pass messages to broadcast(), modified message should be routed to specific _send()"""
+    ct = CommonTransport()
+    ct._broadcast = mock.Mock()
+
+    message = {"foo": "bar"}
+
+    ct.broadcast(
+        mock.sentinel.destination,
+        message,
+        mangle_for_sending=lambda message: message | {"ham": "spam"},
+    )
+
+    ct._broadcast.assert_called_once_with(
+        mock.sentinel.destination,
+        {"foo": "bar", "ham": "spam"},
+    )
 
 
 def test_create_and_destroy_transactions():

--- a/tests/transport/test_common.py
+++ b/tests/transport/test_common.py
@@ -21,7 +21,7 @@ def test_subscribe_unsubscribe_a_channel():
         mock_callback,
         exclusive=mock.sentinel.exclusive,
         acknowledgement=mock.sentinel.ack,
-        disable_mangling=True,
+        mangle_for_receiving=False,
     )
 
     assert subid
@@ -124,7 +124,7 @@ def test_simple_subscribe_unsubscribe_a_broadcast():
         mock.sentinel.channel,
         mock_callback,
         retroactive=mock.sentinel.retro,
-        disable_mangling=True,
+        mangle_for_receiving=False,
     )
 
     assert subid
@@ -191,19 +191,21 @@ def test_broadcast_subscription_messages_custom_mangling_function():
     )
 
 
-@pytest.mark.parametrize("mangling", [None, True, False])
-def test_callbacks_can_be_intercepted(mangling):
+@pytest.mark.parametrize("mangle_for_receiving", [None, True, False])
+def test_callbacks_can_be_intercepted(mangle_for_receiving):
     """The function called on message receipt must be interceptable."""
     ct = CommonTransport()
     ct._subscribe = mock.Mock()
     mock_true_callback = mock.Mock()
     intercept = mock.Mock()
 
-    if mangling is None:
+    if mangle_for_receiving is None:
         subid = ct.subscribe(mock.sentinel.channel, mock_true_callback)
     else:
         subid = ct.subscribe(
-            mock.sentinel.channel, mock_true_callback, disable_mangling=mangling
+            mock.sentinel.channel,
+            mock_true_callback,
+            mangle_for_receiving=mangle_for_receiving,
         )
 
     # Original code path

--- a/tests/transport/test_pika.py
+++ b/tests/transport/test_pika.py
@@ -603,7 +603,7 @@ def test_messages_are_deserialized_after_transport(mock_pikathread):
 
     # Test subscriptions with mangling disabled
     callback = mock.Mock()
-    transport.subscribe("queue", callback, disable_mangling=True)
+    transport.subscribe("queue", callback, mangle_for_receiving=False)
     message_handler = mock_pikathread.subscribe_queue.call_args[1]["callback"]
     message_handler(mock.Mock(), mock.Mock(), mock_properties, banana_str)
     callback.assert_called_once()
@@ -613,7 +613,7 @@ def test_messages_are_deserialized_after_transport(mock_pikathread):
 
     # Test broadcast subscriptions with mangling disabled
     callback = mock.Mock()
-    transport.subscribe_broadcast("queue", callback, disable_mangling=True)
+    transport.subscribe_broadcast("queue", callback, mangle_for_receiving=False)
     message_handler = mock_pikathread.subscribe_broadcast.call_args[1]["callback"]
     message_handler(mock.Mock(), mock.Mock(), mock_properties, banana_str)
     callback.assert_called_once()

--- a/tests/transport/test_stomp.py
+++ b/tests/transport/test_stomp.py
@@ -441,14 +441,14 @@ def test_messages_are_deserialized_after_transport(mockstomp):
 
     # Test subscriptions with mangling disabled
     callback = mock.Mock()
-    stomp.subscribe("channel", callback, disable_mangling=True)
+    stomp.subscribe("channel", callback, mangle_for_receiving=False)
     subscription_id = mockconn.subscribe.call_args[0][1]
     message_handler(_frame({"subscription": subscription_id}, banana_str))
     callback.assert_called_once_with({"subscription": subscription_id}, banana_str)
 
     # Test broadcast subscriptions with mangling disabled
     callback = mock.Mock()
-    stomp.subscribe_broadcast("channel", callback, disable_mangling=True)
+    stomp.subscribe_broadcast("channel", callback, mangle_for_receiving=False)
     subscription_id = mockconn.subscribe.call_args[0][1]
     message_handler(_frame({"subscription": subscription_id}, banana_str))
     callback.assert_called_once_with({"subscription": subscription_id}, banana_str)


### PR DESCRIPTION
This enables overriding the default message mangling on a per-send/broadcast or per-subscription basis, e.g. if certain messages/subscriptions require alternative (de)serialization formats.