### PR TITLE
functools.partial objects don't have __qualname__

### DIFF
--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -85,14 +85,14 @@ class PrometheusMiddleware(BaseTransportMiddleware):
 
     @staticmethod
     def get_callback_source(callable: Callable):
-        module = inspect.getmodule(callable)
         if isinstance(callable, functools.partial):
             # functools.partial objects don't have a __qualname__ attribute
             # account for possibility of nested stack of functools.partials
-            qualname = PrometheusMiddleware.get_callback_source(callable.func)
+            return PrometheusMiddleware.get_callback_source(callable.func)
         else:
             # if defined, used the __qualname__ attribute, else fallback on the repr
             qualname = getattr(callable, "__qualname__", repr(callable).split("(")[0])
+        module = inspect.getmodule(callable)
         if module:
             return f"{module.__name__}:{qualname}"
         return qualname

--- a/src/workflows/transport/middleware/prometheus.py
+++ b/src/workflows/transport/middleware/prometheus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import inspect
 import time
 from typing import Callable, Optional
@@ -85,9 +86,16 @@ class PrometheusMiddleware(BaseTransportMiddleware):
     @staticmethod
     def get_callback_source(callable: Callable):
         module = inspect.getmodule(callable)
+        if isinstance(callable, functools.partial):
+            # functools.partial objects don't have a __qualname__ attribute
+            # account for possibility of nested stack of functools.partials
+            qualname = PrometheusMiddleware.get_callback_source(callable.func)
+        else:
+            # if defined, used the __qualname__ attribute, else fallback on the repr
+            qualname = getattr(callable, "__qualname__", repr(callable).split("(")[0])
         if module:
-            return f"{module.__name__}:{callable.__qualname__}"
-        return callable.__qualname__
+            return f"{module.__name__}:{qualname}"
+        return qualname
 
     def subscribe(self, call_next: Callable, channel, callback, **kwargs) -> int:
         def wrapped_callback(header, message):

--- a/tests/transport/test_middleware.py
+++ b/tests/transport/test_middleware.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import time
 from unittest import mock
@@ -126,3 +127,36 @@ workflows_transport_transactions_in_progress{source="foo"} 1.0
 """
     for line in expected_output.splitlines():
         assert line in data
+
+
+def example_callback(header, message):
+    pass
+
+
+example_functools_partial_callback = functools.partial(
+    example_callback, message={"foo": "bar"}
+)
+example_nested_functools_partial_callback = functools.partial(
+    example_functools_partial_callback, header={"ham": "spam"}
+)
+
+
+def test_get_callback_source():
+    from workflows.transport.middleware import prometheus
+
+    assert (
+        prometheus.PrometheusMiddleware.get_callback_source(example_callback)
+        == "test_middleware:example_callback"
+    )
+    assert (
+        prometheus.PrometheusMiddleware.get_callback_source(
+            example_functools_partial_callback
+        )
+        == "test_middleware:example_callback"
+    )
+    assert (
+        prometheus.PrometheusMiddleware.get_callback_source(
+            example_nested_functools_partial_callback
+        )
+        == "test_middleware:example_callback"
+    )


### PR DESCRIPTION
So attempt to lookup the `__qualname__` of the `.func` attribute of the partial object