### PR TITLE
Improved log format of TimerMiddleware

### DIFF
--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -122,13 +122,13 @@ class ServiceStarter:
         )
 
         # Set up on_transport_preparation hook to affect newly created transport objects
-        true_transport_factory_call = transport_factory.__call__
+        true_transport_factory = transport_factory
 
         def on_transport_preparation_hook():
-            transport_object = true_transport_factory_call()
+            transport_object = true_transport_factory()
             return self.on_transport_preparation(transport_object) or transport_object
 
-        transport_factory.__call__ = on_transport_preparation_hook
+        transport_factory = on_transport_preparation_hook
 
         # When service name is specified, check if service exists or can be derived
         if options.service and options.service not in known_services:

--- a/tests/contrib/test_start_service.py
+++ b/tests/contrib/test_start_service.py
@@ -43,7 +43,7 @@ def test_script_initialises_transport_and_starts_frontend(
     )
     mock_frontend.Frontend.assert_called_once_with(
         service="SomeService",
-        transport=mock_tlookup.return_value,
+        transport=mock.ANY,
         environment={},
     )
     mock_frontend.Frontend.return_value.run.assert_called_once_with()
@@ -68,20 +68,23 @@ def test_add_metrics_option(mock_services, mock_frontend, mock_tlookup, mock_par
         version=mock.sentinel.version,
         add_metrics_option=True,
     )
+    mock_tlookup.assert_called_once_with(mock.sentinel.transport)
     mock_frontend.Frontend.assert_called_once_with(
         service="SomeService",
-        transport=mock_tlookup.return_value,
+        transport=mock.ANY,
         environment={},
     )
 
+    mock_tlookup.reset_mock()
     mock_options.metrics = True
     workflows.contrib.start_service.ServiceStarter().run(
         cmdline_args=["-s", "some", "--metrics"],
         version=mock.sentinel.version,
         add_metrics_option=True,
     )
+    mock_tlookup.assert_called_once_with(mock.sentinel.transport)
     mock_frontend.Frontend.assert_called_with(
         service="SomeService",
-        transport=mock_tlookup.return_value,
+        transport=mock.ANY,
         environment={"metrics": {"port": 4242}},
     )

--- a/tests/transport/test_middleware.py
+++ b/tests/transport/test_middleware.py
@@ -48,18 +48,21 @@ def test_counter_middleware():
 def test_timer_middleware(caplog):
     offline = OfflineTransport()
     offline.connect()
-    timer = middleware.TimerMiddleware()
+    timer = middleware.TimerMiddleware(level=logging.DEBUG)
     offline.add_middleware(timer)
 
     def callback(header, message):
         time.sleep(1)
 
     subscription_id = offline.subscribe(str(mock.sentinel.channel), callback)
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         offline.subscription_callback(subscription_id)(
             {"destination": "foo"}, str(mock.sentinel.message)
         )
-        assert "Callback for foo took:" in caplog.text
+        assert (
+            "Callback for test_middleware:test_timer_middleware.<locals>.callback took"
+            in caplog.text
+        )
 
 
 def test_prometheus_middleware():
@@ -142,21 +145,15 @@ example_nested_functools_partial_callback = functools.partial(
 
 
 def test_get_callback_source():
-    from workflows.transport.middleware import prometheus
-
     assert (
-        prometheus.PrometheusMiddleware.get_callback_source(example_callback)
+        middleware.get_callback_source(example_callback)
         == "test_middleware:example_callback"
     )
     assert (
-        prometheus.PrometheusMiddleware.get_callback_source(
-            example_functools_partial_callback
-        )
+        middleware.get_callback_source(example_functools_partial_callback)
         == "test_middleware:example_callback"
     )
     assert (
-        prometheus.PrometheusMiddleware.get_callback_source(
-            example_nested_functools_partial_callback
-        )
+        middleware.get_callback_source(example_nested_functools_partial_callback)
         == "test_middleware:example_callback"
     )


### PR DESCRIPTION
* Move `get_callback_source()` up to parent middleware module
* Fix service starter transport hook
  Since `transport_factory` is usually the transport class, we call the  `__init__` method rather than a `__call__` method, hence the existing implementation would never call the `on_transport_factory_preparation()` hook.