### PR TITLE
Sample pipethrough

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ workflows.services =
     SampleProducer = workflows.services.sample_producer:SampleProducer
     SampleTxn = workflows.services.sample_transaction:SampleTxn
     SampleTxnProducer = workflows.services.sample_transaction:SampleTxnProducer
+    SamplePipethrough = workflows.services.sample_pipethrough:SamplePipethrough
 workflows.transport =
     PikaTransport = workflows.transport.pika_transport:PikaTransport
     StompTransport = workflows.transport.stomp_transport:StompTransport

--- a/src/workflows/services/sample_pipethrough.py
+++ b/src/workflows/services/sample_pipethrough.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 
+import workflows.recipe
 from workflows.services.common_service import CommonService
 
 
@@ -21,7 +22,7 @@ class SamplePipethrough(CommonService):
         """Subscribe to a channel."""
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "sample_pipethrough",
+            "transient.destination",
             self.process,
         ) 
 
@@ -40,5 +41,5 @@ class SamplePipethrough(CommonService):
             f"=== Consume ====\n{header_str}{message}\nReceived message @{t:10.3f} ms"
         )
         
-        rw.send()
+        rw.send(0)
 

--- a/src/workflows/services/sample_pipethrough.py
+++ b/src/workflows/services/sample_pipethrough.py
@@ -17,3 +17,6 @@ class SamplePipethrough(CommonService):
     # Logger name
     _logger_name = "workflows.service.sample_pipethrough"
 
+    def initializing(self):
+        """Subscribe to a channel."""
+

--- a/src/workflows/services/sample_pipethrough.py
+++ b/src/workflows/services/sample_pipethrough.py
@@ -1,4 +1,4 @@
-form __future__ import annotation
+from __future__ import annotations
 
 import json
 import time

--- a/src/workflows/services/sample_pipethrough.py
+++ b/src/workflows/services/sample_pipethrough.py
@@ -19,4 +19,26 @@ class SamplePipethrough(CommonService):
 
     def initializing(self):
         """Subscribe to a channel."""
+        workflows.recipe.wrap_subscribe(
+            self._transport,
+            "sample_pipethrough",
+            self.process,
+        ) 
+
+    def process(self, rw, header, message):
+        """Consume message and send to output pipe."""
+        t = (time.time() % 1000) * 1000
+
+        if header:
+            header_str = json.dumps(header, indent=2) + "\n" + "----------------" + "\n"
+        else:
+            header_str = ""
+        if isinstance(message, dict):
+            message = json.dumps(message, indent=2) + "\n" + "----------------" + "\n"
+
+        self.log.info(
+            f"=== Consume ====\n{header_str}{message}\nReceived message @{t:10.3f} ms"
+        )
+        
+        rw.send()
 

--- a/src/workflows/services/sample_pipethrough.py
+++ b/src/workflows/services/sample_pipethrough.py
@@ -1,0 +1,19 @@
+form __future__ import annotation
+
+import json
+import time
+
+from workflows.services.common_service import CommonService
+
+
+class SamplePipethrough(CommonService):
+    """An example services building on top of the workflow.services architecture,
+    demonstrating how this architecture can be used.
+    This services consumes messages off a queue, and forwards to another."""
+
+    # Human readable service name
+    _service_name = "Message Pipethrough"
+
+    # Logger name
+    _logger_name = "workflows.service.sample_pipethrough"
+


### PR DESCRIPTION
Adds the sample pipethrough service.

The sample producer and sample consumer services allow a message to be sent between them. The sample pipethrough service produces a test service which can be used to both receive and send messages in a recipe.

This is useful to test features that need some basic functionality over multiple services, such as distributed tracing.