### PR TITLE
Changed PikaTransport._call_message_callback for readability

### DIFF
--- a/src/workflows/transport/pika_transport.py
+++ b/src/workflows/transport/pika_transport.py
@@ -341,7 +341,9 @@ class PikaTransport(CommonTransport):
                 "subscription": subscription_id,
             }
         )
-        self.subscription_callback(subscription_id)(
+        target_function = self.subscription_callback(subscription_id)
+
+        target_function(
             merged_headers,
             body,
         )


### PR DESCRIPTION
Separates what (I think) should be two commands, which is the default in StompTransport.