### PR TITLE
Check a valid service name has been provided

### DIFF
--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -47,12 +47,12 @@ class ServiceStarter:
         value is returned here it will replace the Frontend object."""
 
     def run(
-        self,
-        cmdline_args=None,
-        program_name="start_service",
-        version=None,
-        add_metrics_option: bool = False,
-        **kwargs,
+            self,
+            cmdline_args=None,
+            program_name="start_service",
+            version=None,
+            add_metrics_option: bool = False,
+            **kwargs,
     ):
         """Example command line interface to start services.
         :param cmdline_args: List of command line arguments to pass to parser
@@ -115,13 +115,12 @@ class ServiceStarter:
                 action="store_true",
                 default=False,
                 help=(
-                    "Record metrics for this service and expose them on the port defined by"
-                    "the --metrics-port option."
+                    "Record metrics for this service and expose them on the port "
+                    "defined by the --metrics-port option."
                 ),
             )
             parser.add_option(
                 "--metrics-port",
-                dest="metrics_port",
                 default=8080,
                 type="int",
                 help="Expose metrics via a prometheus endpoint on this port.",
@@ -142,8 +141,8 @@ class ServiceStarter:
 
         # Call on_transport_factory_preparation hook
         transport_factory = (
-            self.on_transport_factory_preparation(transport_factory)
-            or transport_factory
+                self.on_transport_factory_preparation(transport_factory)
+                or transport_factory
         )
 
         # Set up on_transport_preparation hook to affect newly created transport objects

--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -62,6 +62,7 @@ class ServiceStarter:
 
         # Enumerate all known services
         known_services = sorted(workflows.services.get_known_services())
+        known_services_help = "Known services: " + ", ".join(known_services)
 
         if version:
             version = f"{version} (workflows {workflows.version()})"
@@ -76,15 +77,11 @@ class ServiceStarter:
         parser.add_option(
             "-s",
             "--service",
-            dest="service",
             metavar="SVC",
-            default=None,
-            help="Name of the service to start. Known services: "
-            + ", ".join(known_services),
+            help=f"Name of the service to start. {known_services_help}",
         )
         parser.add_option(
             "--liveness",
-            dest="liveness",
             action="store_true",
             default=False,
             help=(
@@ -95,14 +92,12 @@ class ServiceStarter:
         )
         parser.add_option(
             "--liveness-port",
-            dest="liveness_port",
             default=8000,
             type="int",
             help="Expose liveness check endpoint on this port.",
         )
         parser.add_option(
             "--liveness-timeout",
-            dest="liveness_timeout",
             default=30,
             type="float",
             help="Timeout for the liveness check (in seconds).",
@@ -111,7 +106,6 @@ class ServiceStarter:
             parser.add_option(
                 "-m",
                 "--metrics",
-                dest="metrics",
                 action="store_true",
                 default=False,
                 help=(
@@ -135,6 +129,10 @@ class ServiceStarter:
 
         # Call on_parsing hook
         (options, args) = self.on_parsing(options, args) or (options, args)
+
+        # Exit with error if no service has been specified.
+        if not options.service:
+            parser.error(f"Please specify a service name. {known_services_help}")
 
         # Create Transport factory
         transport_factory = workflows.transport.lookup(options.transport)

--- a/src/workflows/contrib/start_service.py
+++ b/src/workflows/contrib/start_service.py
@@ -49,12 +49,12 @@ class ServiceStarter:
         value is returned here it will replace the Frontend object."""
 
     def run(
-            self,
-            cmdline_args=None,
-            program_name="start_service",
-            version=None,
-            add_metrics_option: bool = False,
-            **kwargs,
+        self,
+        cmdline_args=None,
+        program_name="start_service",
+        version=None,
+        add_metrics_option: bool = False,
+        **kwargs,
     ):
         """Example command line interface to start services.
         :param cmdline_args: List of command line arguments to pass to parser
@@ -141,8 +141,8 @@ class ServiceStarter:
 
         # Call on_transport_factory_preparation hook
         transport_factory = (
-                self.on_transport_factory_preparation(transport_factory)
-                or transport_factory
+            self.on_transport_factory_preparation(transport_factory)
+            or transport_factory
         )
 
         # Set up on_transport_preparation hook to affect newly created transport objects
@@ -157,28 +157,29 @@ class ServiceStarter:
         # When service name is specified, check if service exists or can be derived.
         if options.service not in known_services:
             # First check whether the provided service name is a case-insensitive match.
-            svc_lower = options.service.lower()
-            match = {s.lower(): s for s in known_services}.get(svc_lower, None)
-            match = [match] if match else []
+            service_lower = options.service.lower()
+            match = {s.lower(): s for s in known_services}.get(service_lower, None)
+            match = (
+                [match]
+                if match
+                # Next, check whether the provided service name is a partial
+                # case-sensitive match.
+                else [s for s in known_services if s.startswith(options.service)]
+                # Next check whether the provided service name is a partial
+                # case-insensitive match.
+                or [s for s in known_services if s.lower().startswith(service_lower)]
+            )
 
-            # Next, check whether the provided service name is a unique partial
-            # case-sensitive match.
-            if not match:
-                match = [s for s in known_services if s.startswith(options.service)]
-
-            # Next check whether the provided service name is a unique partial
-            # case-insensitive match.
-            if not match:
-                match = [s for s in known_services if s.lower().startswith(svc_lower)]
-
-            # Set the service name to the derived value, or exit with an error.
+            # Catch ambiguous partial matches and exit with an error.
             if len(match) > 1:
                 sys.exit(
                     f"Specified service name {options.service} is ambiguous, partially "
                     f"matching each of these known services: " + ", ".join(match)
                 )
+            # Otherwise, set the derived service name, if there's a unique match.
             elif match:
-                options.service, = match
+                (options.service,) = match
+            # Otherwise, exit with an error.
             else:
                 sys.exit(f"Please specify a valid service name. {known_services_help}")
 


### PR DESCRIPTION
At present, a user can grow accustomed to lazily providing lower-case service names when invoking `workflows.service` from the command line.  This works fine until you encounter the following situation:
- Known services include `DLSISPyB` and `DLSISPyBPIA`;
- user specifies `-s dlsispyb`, expecting this to be interpreted as `DLSISPyB`, or else expecting an error;
- not finding a perfect match, the current logic checks whether any known service names, rendered in lower case, start with `dlsispyb`, finds two such matches;
- rather than selecting either of these two matches, the program quietly continues to open a frontend and doesn't start any service;
- user sees so warning or error, program twiddles its thumbs until manually terminated.

New logic:
1. Check for perfect match;
2. Failing that, check for case-insensitive match;
3. Failing that, check for case-sensitive partial matches.  If ambiguous, exit with error.
4. Failing that, repeat 3 but now case-insensitive.
5. If still no matches, exit with error.