### PR TITLE
Update stomp dependency to more a standard name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     bidict
     pika
     setuptools
-    stomp.py>=7
+    stomp-py>=7
 packages = find:
 package_dir =
     =src


### PR DESCRIPTION
For Hyperion some of our dependencies install stomp as `stomp.py` and some as `stomp-py`. Whilst both are valid for `pip` when making an entry point for some reason that we haven't got to the bottom of using `stomp.py` fails (see https://github.com/DiamondLightSource/hyperion/issues/1346). Given that pypi calls it `stomp-py` and recommends you install it as `pip install stomp-py` it seems sensible to change it here rather than try and fix our downstream issues.

