### PR TITLE
Revert "Remove dependency on pkg_resources in favour of importlib"

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -88,5 +88,7 @@ stages:
           PYTHON_VERSION: 3.10
         python311:
           PYTHON_VERSION: 3.11
+        python312:
+          PYTHON_VERSION: 3.12
     steps:
     - template: ci.yml

--- a/src/workflows/services/__init__.py
+++ b/src/workflows/services/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from importlib.metadata import entry_points
+import pkg_resources
 
 
 def lookup(service: str):
@@ -25,7 +25,10 @@ def get_known_services():
         setattr(
             get_known_services,
             "cache",
-            {e.name: e.load for e in entry_points()["workflows.services"]},
+            {
+                e.name: e.load
+                for e in pkg_resources.iter_entry_points("workflows.services")
+            },
         )
     register = get_known_services.cache.copy()
     return register

--- a/src/workflows/services/__init__.py
+++ b/src/workflows/services/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 
 def lookup(service: str):
@@ -25,10 +25,7 @@ def get_known_services():
         setattr(
             get_known_services,
             "cache",
-            {
-                e.name: e.load
-                for e in pkg_resources.iter_entry_points("workflows.services")
-            },
+            {e.name: e.load for e in entry_points()["workflows.services"]},
         )
     register = get_known_services.cache.copy()
     return register

--- a/src/workflows/transport/__init__.py
+++ b/src/workflows/transport/__init__.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import argparse
 import optparse
+from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Type
-
-import pkg_resources
 
 if TYPE_CHECKING:
     from .common_transport import CommonTransport
@@ -61,9 +60,6 @@ def get_known_transports() -> dict[str, Type[CommonTransport]]:
         setattr(
             get_known_transports,
             "cache",
-            {
-                e.name: e.load()
-                for e in pkg_resources.iter_entry_points("workflows.transport")
-            },
+            {e.name: e.load() for e in entry_points()["workflows.transport"]},
         )
     return get_known_transports.cache.copy()  # type: ignore

--- a/src/workflows/transport/__init__.py
+++ b/src/workflows/transport/__init__.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import optparse
-from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Type
+
+import pkg_resources
 
 if TYPE_CHECKING:
     from .common_transport import CommonTransport
@@ -60,6 +61,9 @@ def get_known_transports() -> dict[str, Type[CommonTransport]]:
         setattr(
             get_known_transports,
             "cache",
-            {e.name: e.load() for e in entry_points()["workflows.transport"]},
+            {
+                e.name: e.load()
+                for e in pkg_resources.iter_entry_points("workflows.transport")
+            },
         )
     return get_known_transports.cache.copy()  # type: ignore

--- a/tests/services/test.py
+++ b/tests/services/test.py
@@ -1,8 +1,21 @@
 from __future__ import annotations
 
 import workflows.services
+from workflows.services.common_service import CommonService
 
 
 def test_known_services_is_a_dictionary():
     """Check services register build in CommonService."""
     assert isinstance(workflows.services.get_known_services(), dict)
+
+
+def test_enumerate_services():
+    """Verify we can discover the installed services."""
+    services = workflows.services.get_known_services()
+    assert services.keys() == {
+        "SampleConsumer",
+        "SampleProducer",
+        "SampleTxn",
+        "SampleTxnProducer",
+    }
+    assert all([issubclass(service(), CommonService) for service in services.values()])

--- a/tests/services/test.py
+++ b/tests/services/test.py
@@ -1,21 +1,8 @@
 from __future__ import annotations
 
 import workflows.services
-from workflows.services.common_service import CommonService
 
 
 def test_known_services_is_a_dictionary():
     """Check services register build in CommonService."""
     assert isinstance(workflows.services.get_known_services(), dict)
-
-
-def test_enumerate_services():
-    """Verify we can discover the installed services."""
-    services = workflows.services.get_known_services()
-    assert services.keys() == {
-        "SampleConsumer",
-        "SampleProducer",
-        "SampleTxn",
-        "SampleTxnProducer",
-    }
-    assert all([issubclass(service(), CommonService) for service in services.values()])

--- a/tests/transport/test.py
+++ b/tests/transport/test.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
 import workflows.transport
+from workflows.transport.common_transport import CommonTransport
 
 
 def test_known_transports_is_a_dictionary():
     """Check transport register build in CommonTransport."""
-    assert isinstance(workflows.transport.get_known_transports(), dict)
+    transports = workflows.transport.get_known_transports()
+    print(transports)
+    assert isinstance(transports, dict)
+
+
+def test_enumerate_transports():
+    """Verify we can discover the installed transports."""
+    transports = workflows.transport.get_known_transports()
+    assert transports.keys() == {"OfflineTransport", "PikaTransport", "StompTransport"}
+    assert all(
+        [issubclass(transport, CommonTransport) for transport in transports.values()]
+    )
 
 
 def test_load_any_transport():

--- a/tests/transport/test.py
+++ b/tests/transport/test.py
@@ -1,23 +1,11 @@
 from __future__ import annotations
 
 import workflows.transport
-from workflows.transport.common_transport import CommonTransport
 
 
 def test_known_transports_is_a_dictionary():
     """Check transport register build in CommonTransport."""
-    transports = workflows.transport.get_known_transports()
-    print(transports)
-    assert isinstance(transports, dict)
-
-
-def test_enumerate_transports():
-    """Verify we can discover the installed transports."""
-    transports = workflows.transport.get_known_transports()
-    assert transports.keys() == {"OfflineTransport", "PikaTransport", "StompTransport"}
-    assert all(
-        [issubclass(transport, CommonTransport) for transport in transports.values()]
-    )
+    assert isinstance(workflows.transport.get_known_transports(), dict)
 
 
 def test_load_any_transport():


### PR DESCRIPTION
#181

This ran into the python 3.12 importlib compatibility issue.

This reverts commit 28dc03509b9599fb73100235f3ac5a4fc53d594c.