### PR TITLE
Zocalo plugin tweaks: Return configuration objects

### DIFF
--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -48,6 +48,7 @@ class Stomp:
             ("prefix", "--stomp-prfx"),
         ]:
             StompTransport.defaults[target] = configuration[cfgoption]
+        return dict(StompTransport.defaults)
 
 
 class Pika:
@@ -70,6 +71,7 @@ class Pika:
             ("vhost", "--rabbit-vhost"),
         ]:
             PikaTransport.defaults[target] = configuration[cfgoption]
+        return dict(PikaTransport.defaults)
 
 
 class DefaultTransport:

--- a/src/workflows/util/zocalo/configuration.py
+++ b/src/workflows/util/zocalo/configuration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar, TypedDict
+
 from marshmallow import fields
 from zocalo.configuration import PluginSchema
 
@@ -11,13 +13,17 @@ from workflows.transport.stomp_transport import StompTransport
 class OTEL:
     """A Zocalo configuration plugin to pre-populate OTELTracing config defaults"""
 
+    class _OTELConfig(TypedDict, total=False):
+        endpoint: str
+        timeout: int
+
+    # Store configuration for access by services
+    config: ClassVar[_OTELConfig] = {}
+
     class Schema(PluginSchema):
         host = fields.Str(required=True)
         port = fields.Int(required=True)
         timeout = fields.Int(required=False, load_default=10)
-
-    # Store configuration for access by services
-    config = {}
 
     @staticmethod
     def activate(configuration):
@@ -25,7 +31,7 @@ class OTEL:
         endpoint = f"https://{configuration['host']}:{configuration['port']}/v1/traces"
         OTEL.config["endpoint"] = endpoint
         OTEL.config["timeout"] = configuration.get("timeout", 10)
-        return OTEL.config
+        return dict(OTEL.config)
 
 
 class Stomp:


### PR DESCRIPTION
This means that the configuration will also be available for lookup on the zocalo configuration object, rather than having to go via the transport type.